### PR TITLE
Objektzugriff ermöglichen

### DIFF
--- a/assets/geo_osm.js
+++ b/assets/geo_osm.js
@@ -19,6 +19,14 @@ var rex_geo_osm = function(addressfields, geofields, id, mapbox_token) {
 
     // Karte laden
 
+    /*
+     * Store a reference of the Leaflet map object on the map container,
+     * so that it could be retrieved from DOM selection.
+     * https://leafletjs.com/reference-1.3.4.html#map-getcontainer
+     */
+    L.Map.addInitHook(function () {
+        this.getContainer()._leaflet_map = this;
+    });
 
     if(mapbox_token=='') {
         var map = L.map('map-'+id).setView([current_lat, current_lng], 16);


### PR DESCRIPTION
Über den Hook wird dem Container eine Referenz zum Mapobjekt hinzugefügt, wodurch der nachträgliche Zugriff ermöglicht wird.

**Anwendungsfall:**
Bei Verwendung innerhalb der Tabs vom "yform_fields" AddOn wird die Karte nicht richtig geladen, da diese sich noch im Hintergrund befindet.
Durch den PR hat man die Möglichkeit über document.querySelector('###selector###')._leaflet_map.invalidateSize() die Karte entsprechend neu der Größe anzupassen.
Siehe auch: [invalidateSize](https://leafletjs.com/reference.html#map-invalidatesize)
Und: https://github.com/Leaflet/Leaflet/issues/6298#issuecomment-415124583