### PR TITLE
DB-Feldtyp varchar statt text / Speicherverhalten geändert

### DIFF
--- a/lib/yform_value_osm_geocode.php
+++ b/lib/yform_value_osm_geocode.php
@@ -34,7 +34,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
                 'mapbox_token' => array ( 'type' => 'text', 'label' => 'Mapbox Token (optional)')
             ),
             'description' => 'Openstreetmap Positionierung',
-            'dbtype' => 'text',
+            'dbtype' => 'varchar(191)',
             'formbuilder' => false,
             'multi_edit' => false,
         );

--- a/lib/yform_value_osm_geocode.php
+++ b/lib/yform_value_osm_geocode.php
@@ -2,43 +2,96 @@
 
 class rex_yform_value_osm_geocode extends rex_yform_value_abstract
 {
+    public ?rex_yform_value_abstract $latField = null;
+    public ?rex_yform_value_abstract $lngField = null;
+    public bool $combinedValue = false;
 
-    function enterObject()
+    /**
+     * Die Hilfsfelder im Formular für Lat/Lng identifizieren.
+     * Falls es reine Hilfsfelder sind (nicht in der DB speichern)
+     * werden ggf. sie aus diesem Feld initialisiert. 
+     */
+    public function preValidateAction(): void
     {
-        $addressfields = explode(',', str_replace(" ", "", $this->getElement('address')));
-        $geofields = explode(',', str_replace(" ", "", $this->getElement('latlng')));
-        $height = intval($this->getElement('height'));
+        /**
+         * Brauchen wir so oder so: die Referenz auf die Lat/Lng-Felder.
+         */
+        if (null === $this->latField || null === $this->lngField) {
+            $geofields = explode(',', str_replace(' ', '', $this->getElement('latlng')));
+            foreach ($this->params['values'] as $val) {
+                if ($val->getName() == $geofields[0]) {
+                    $this->latField = $val;
+                    $this->combinedValue = $this->combinedValue || !$val->saveInDB();
+                }
+                if ($val->getName() == $geofields[1]) {
+                    $this->lngField = $val;
+                    $this->combinedValue = $this->combinedValue || !$val->saveInDB();
+                }
+            }
+            if (null === $this->latField || null === $this->lngField) {
+                throw new rex_functional_exception('Konfigurationsfehler im Feld ' . $this->getName() . ': lat/lng');
+            }
+        }
+
+        /**
+         * Wenn die Felder nicht selbst in der DB gespeichert werden, erhalten Sie den Wert
+         * aus diesem Feld vorbelegt.
+         */
+        if (1 !== $this->params['send'] && $this->combinedValue) {
+            $value = $this->getValue();
+            if (null === $value) {
+                $value = ',';
+            }
+            [$lat, $lng, $rest] = explode(',', $value . ',');
+            $this->latField->setValue($lat);
+            $this->lngField->setValue($lng);
+        }
+    }
+
+    public function enterObject()
+    {
+        $addressfields = explode(',', str_replace(' ', '', $this->getElement('address')));
+        $geofields = [$this->latField->getName(), $this->lngField->getName()];
+        $height = (int) $this->getElement('height');
         $mapbox_token = $this->getElement('mapbox_token');
-        
+
         if ($this->needsOutput()) {
             $this->params['form_output'][$this->getId()] = $this->parse('value.osm_geocode.tpl.php', compact('addressfields', 'geofields', 'height', 'mapbox_token'));
         }
-     }
 
-    function getDescription(): string
+        /**
+         * Lat und Lng wieder zusammenfassen und speichern.
+         */
+        $this->setValue(sprintf('%s,%s', $this->latField->getValue(), $this->lngField->getValue()));
+
+        $this->params['value_pool']['email'][$this->getName()] = $this->getValue();
+        if ($this->saveInDB()) {
+            $this->params['value_pool']['sql'][$this->getName()] = $this->getValue();
+        }
+    }
+
+    public function getDescription(): string
     {
         return 'osm_geocode|osmgeocode|Bezeichnung|pos_lat,pos_lng|strasse,plz,ort|height|';
     }
 
-    function getDefinitions(): array
+    public function getDefinitions(): array
     {
-        return array(
+        return [
             'type' => 'value',
             'name' => 'osm_geocode',
-            'values' => array(
-                'name'     => array( 'type' => 'name', 'label' => 'Name' ),
-                'label'    => array( 'type' => 'text', 'label' => 'Bezeichnung'),
-                'latlng'  => array( 'type' => 'text', 'label' => 'Feldnamen LAT/LNG (Bsp. pos_lat,pos_lng)'),
-                'address'  => array( 'type' => 'text', 'label' => 'Feldnamen Positionsfindung (Bsp. strasse,plz,ort)'),
-                'height'   => array( 'type' => 'text', 'label' => 'Map-H&ouml;he'),
-                'mapbox_token' => array ( 'type' => 'text', 'label' => 'Mapbox Token (optional)')
-            ),
+            'values' => [
+                'name' => ['type' => 'name', 'label' => 'Name'],
+                'label' => ['type' => 'text', 'label' => 'Bezeichnung'],
+                'latlng' => ['type' => 'text', 'label' => 'Feldnamen LAT/LNG (Bsp. pos_lat,pos_lng)'],
+                'address' => ['type' => 'text', 'label' => 'Feldnamen Positionsfindung (Bsp. strasse,plz,ort)'],
+                'height' => ['type' => 'text', 'label' => 'Map-H&ouml;he'],
+                'mapbox_token' => ['type' => 'text', 'label' => 'Mapbox Token (optional)'],
+            ],
             'description' => 'Openstreetmap Positionierung',
             'dbtype' => 'varchar(191)',
             'formbuilder' => false,
             'multi_edit' => false,
-        );
-
+        ];
     }
-
 }


### PR DESCRIPTION
Die Koordinate in einem `text`-Feld der DB zu speichern scheint mir doch etwas verschwenderisch. `varchar(191)` sollte reichen.

In Ergänzumg zu #30 habe ich mal was Zusätzliches eingebaut:

Wenn eines oder beide Felder für lat und lng als "nicht in der DB speichern" gekennzeichnet sind, wird statt dessen der Inhalt der Felder als `lat,lng` zusammengefasst und im bisher leeren eigenen Feld gespeichert. Analog dazu wird beim initialen Aufruf des Formulars der eigene Feldinhalt auf lat/lng verteilt.

Die Lösung wäre kompatibel zum Bestehenden, bietet aber Mehrwert für alle, die lat/lng in einem feld speichern (so wie jetzt beim alten YForm-Feld google_geocode (Da müsste man nur die zwei Felder lat/lng passend konfiguriert hinzufügen).