### PR TITLE
RexStan eingesetzt, Value mit Validierung der Feldkonfiguration

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -7,38 +7,34 @@ use rex_url;
 
 class Assets
 {
-
     /**
      * @api
+     * @param rex_extension_point<string> $ep
      */
-
-    public static function addAssets(rex_extension_point $ep) : string
+    public static function addAssets(rex_extension_point $ep): string
     {
-
         $assets_header = '
-			<link rel="stylesheet" type="text/css" media="all" href="'.rex_url::addonAssets('yform_geo_osm', 'leaflet/leaflet.css').'" />
-   			 <link rel="stylesheet" type="text/css" media="all" href="'.rex_url::addonAssets('yform_geo_osm', 'geo_osm.css').'" />
+			<link rel="stylesheet" type="text/css" media="all" href="' . rex_url::addonAssets('yform_geo_osm', 'leaflet/leaflet.css') . '" />
+   			 <link rel="stylesheet" type="text/css" media="all" href="' . rex_url::addonAssets('yform_geo_osm', 'geo_osm.css') . '" />
     		</head>
 		';
 
         $assets_footer = '
-   			 <script type="text/javascript" src="'.rex_url::addonAssets('yform_geo_osm', 'leaflet/leaflet.js').'" ></script>
-    		<script type="text/javascript" src="'.rex_url::addonAssets('yform_geo_osm', 'geo_osm.js').'" ></script>
+   			 <script type="text/javascript" src="' . rex_url::addonAssets('yform_geo_osm', 'leaflet/leaflet.js') . '" ></script>
+    		<script type="text/javascript" src="' . rex_url::addonAssets('yform_geo_osm', 'geo_osm.js') . '" ></script>
     		</body>
 		';
 
         return str_replace(['</head>', '</body>'], [$assets_header, $assets_footer], $ep->getSubject());
-
     }
 
     /**
      * @api
+     * @param rex_extension_point<string> $ep
      */
-
-    public static function addDynJs(rex_extension_point $ep) : string
+    public static function addDynJs(rex_extension_point $ep): string
     {
         $js = $ep->getParam('js');
-        return str_replace('</body>', $js.'</body>', $ep->getSubject());
+        return str_replace('</body>', $js . '</body>', $ep->getSubject());
     }
-
 }

--- a/lib/yfom/value/osm_geocode.php
+++ b/lib/yfom/value/osm_geocode.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace FriendsOfRedaxo\YFormGeoOsm;
-
 use rex_functional_exception;
 use rex_i18n;
 use rex_yform_value_abstract;
@@ -13,11 +11,12 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     protected ?rex_yform_value_abstract $latField = null;
     protected ?rex_yform_value_abstract $lngField = null;
     protected bool $combinedValue = false;
+    protected rex_yform_value_abstract $latLngInput;
 
     /**
      * Die Hilfsfelder im Formular für Lat/Lng identifizieren.
-     * Falls es reine Hilfsfelder sind (nicht in der DB speichern)
-     * werden ggf. sie aus diesem Feld initialisiert.
+     * Falls es reine Hilfsfelder sind (no_db) werden die Felder
+     * beim ersten Aufruf vorbefüllt mit den Daten aus diesem Feld.
      *
      * @api
      */
@@ -32,6 +31,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
                 if ($val->getName() === $geofields[0]) {
                     $this->latField = $val;
                     $this->combinedValue = $this->combinedValue || !$val->saveInDB();
+                    continue;
                 }
                 if ($val->getName() === $geofields[1]) {
                     $this->lngField = $val;
@@ -44,7 +44,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         }
 
         /**
-         * Wenn die Felder nicht selbst in der DB gespeichert werden, erhalten Sie den Wert
+         * Wenn die Felder nicht selbst in der DB gespeichert werden (no_db), erhalten Sie den Wert
          * aus diesem Feld vorbelegt.
          */
         if (1 !== $this->params['send'] && $this->combinedValue) {
@@ -59,6 +59,9 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     }
 
     /**
+     * HTML für das Feld generieren
+     * Daten ggf. speichern
+     * 
      * @api
      */
     public function enterObject(): void
@@ -101,18 +104,216 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
             'type' => 'value',
             'name' => 'osm_geocode',
             'values' => [
-                'name' => ['type' => 'name', 'label' => 'Name'],
-                'label' => ['type' => 'text', 'label' => 'Bezeichnung'],
-                'latlng' => ['type' => 'text', 'label' => 'Feldnamen LAT/LNG (Bsp. pos_lat,pos_lng)'],
-                'address' => ['type' => 'text', 'label' => 'Feldnamen Positionsfindung (Bsp. strasse,plz,ort)'],
-                'height' => ['type' => 'text', 'label' => 'Map-H&ouml;he'],
-                'mapbox_token' => ['type' => 'text', 'label' => 'Mapbox Token (optional)'],
-                'no_db' => ['type' => 'no_db',   'label' => rex_i18n::msg('yform_values_defaults_table'),  'default' => 0],
+                'name' => [
+                        'type' => 'name',
+                        'label' => 'Name',
+                    ],
+                'label' => [
+                        'type' => 'text',
+                        'label' => 'Bezeichnung',
+                    ],
+                'latlng' => [
+                        'type' => 'text',
+                        'label' => 'Koordinaten-Felder',
+                        'notice' => 'Namen der Felder für Breitengrad/Latitude und Längengrad/Longitude; Bsp.: «pos_lat,pos_lng»',
+                    ],
+                'address' => [
+                        'type' => 'text',
+                        'label' => 'Adressen-Felder',
+                        'notice' => 'Namen der Felder mit Adressen-Elementen zur Positionsfindung; Bsp.: «strasse,plz,ort»',
+                    ],
+                'height' => [
+                        'type' => 'text',
+                        'label' => 'Map-H&ouml;he',
+                    ],
+                'mapbox_token' => [
+                        'type' => 'text',
+                        'label' => 'Mapbox-Token',
+                        'notice' => '(optional)',
+                    ],
+                'no_db' => [
+                        'type' => 'no_db',
+                        'default' => 0,
+                    ],
+            ],
+            'validates' => [
+                ['customfunction' => ['name' => 'latlng', 'function' => $this->validateLatLng(...)]],
+                ['customfunction' => ['name' => 'address', 'function' => $this->validateAddress(...)]],
+                ['customfunction' => ['name' => 'no_db', 'function' => $this->validateNoDb(...)]],
             ],
             'description' => 'Openstreetmap Positionierung',
             'dbtype' => 'varchar(191)',
             'formbuilder' => false,
             'multi_edit' => false,
         ];
+    }
+
+    /**
+     * Validator für die Feld-Konfiguration
+     * 
+     * Überprüft, ob die angegebenen Felder für LAT/LNG existieren.
+     * Wenn nein: Fehlermeldung.
+     * Wenn ungleich 2 Felder: Fehlermeldung
+     * Wenn ja: schon mal versehentlich eingegebene Leerzeichen entfernen.
+     *
+     * @param array<rex_yform_value_abstract> $fields
+     */
+    protected function validateLatLng(string $field_name, string $value, bool $return, rex_yform_validate_customfunction $self, array $fields): bool
+    {
+        /**
+         * Eingabe in ein Array auflösen und formal bereinigen.
+         */
+        $coord_field_names = array_map(trim(...), explode(',', $value));
+        $coord_field_names = array_filter($coord_field_names, strlen(...));
+        $coord_field_names = array_unique($coord_field_names);
+
+        /**
+         * Fehler 1: mehr oder weniger als zwei Felder angegeben.
+         */
+        if (2 !== count($coord_field_names)) {
+            $self->setElement(
+                'message',
+                'Bitte genau zwei Felder für Breiten- und Längengrade (lat, lng) angeben.'
+            );
+            return true;
+        }
+
+        /**
+         * Liste der Feldnamen in der Tabelle abrufen und ermitteln, welches angegebene Feld
+         * nicht im Formular vorkommt.
+         */
+        $sql = rex_sql::factory();
+        $field_list = $sql->getArray(
+            'SELECT id,name FROM ' . rex::getTable('yform_field') . ' WHERE type_id = :ti AND table_name = :tn', 
+            [
+                ':ti' => 'value',
+                ':tn' => $self->getParam('form_hiddenfields')['table_name'],
+            ],
+            PDO::FETCH_KEY_PAIR,
+        );
+
+        /**
+         * Fehler 2: unbekanntes Feld.
+         */
+        $unknown_fields = array_diff($coord_field_names, $field_list);
+        if (0 < count($unknown_fields)) {
+            $self->setElement(
+                'message',
+                sprintf('Koordinaten-Feld unbekannt: «%s»', implode('», «', $unknown_fields))
+            );
+            return true;
+        }
+
+        /**
+         * formal bereinigte Liste in das Feld zurückgeben.
+         */
+        $fields[$field_name]->setValue(implode(',', $coord_field_names));
+        $this->latLngInput = $fields[$field_name];
+        return false;
+    }
+
+    /**
+     * Validator für die Feld-Konfiguration
+     * 
+     * Überprüft, ob die angegebenen Felder für Adress-Teile existieren.
+     * Wenn nein: Fehlermeldung.
+     * Wenn ja: schon mal versehentlich eingegebene Leerzeichen entfernen.
+     * 
+     * @param array<rex_yform_value_abstract> $fields
+     */
+    protected function validateAddress(string $field_name, string $value, bool $return, rex_yform_validate_customfunction $self, array $fields): bool
+    {
+        /**
+         * Eingabe in ein Array auflösen und formal bereinigen.
+         */
+        $address_field_names = array_map(trim(...), explode(',', $value));
+        $address_field_names = array_filter($address_field_names, strlen(...));
+        $address_field_names = array_unique($address_field_names);
+
+        /**
+         * Liste der Feldnamen in der Tabelle abrufen und ermitteln, welches angegebene Feld
+         * nicht im Formular vorkommt.
+         */
+        $sql = rex_sql::factory();
+        $field_list = $sql->getArray(
+            'SELECT id,name FROM ' . rex::getTable('yform_field') . ' WHERE type_id = :ti AND table_name = :tn',
+            [
+                ':ti' => 'value',
+             ':tn' => $self->getParam('form_hiddenfields')['table_name'],
+            ],
+            PDO::FETCH_KEY_PAIR,
+        );
+
+        /**
+         * Fehler: unbekanntes Feld.
+         */
+        $unknown_fields = array_diff($address_field_names, $field_list);        
+        if (0 < count($unknown_fields)) {
+            $self->setElement(
+                'message',
+                sprintf('Adress-Feld unbekannt: «%s»', implode('», «', $unknown_fields))
+            );
+            return true;
+        }
+
+        /**
+         * formal bereinigte Liste in das Feld zurückgeben.
+         */
+        $fields[$field_name]->setValue(implode(',', $address_field_names));
+        return false;
+    }
+
+    /**
+     * Validator für die Feld-Konfiguration
+     * 
+     * Überprüft, ob die angegebenen Felder für Adress-Teile existieren.
+     * Wenn nein: Fehlermeldung.
+     * Wenn ja: schon mal versehentlich eingegebene Leerzeichen entfernen.
+     * 
+     * @param array<rex_yform_value_abstract> $fields
+     */
+    protected function validateNoDb(string $field_name, ?int $value, bool $return, rex_yform_validate_customfunction $self, array $fields): bool
+    {
+        /**
+         * Überspringen wenn selbst speicherbar bzw. die LatLng-Überprüfung gescheitert ist.
+         */
+        if( $value === null || $value === 0 || !isset($this->latLngInput)) {
+            return false;
+        }
+
+        /**
+         * Die Lat/Lng-Felder identifizieren und auf _no_db prüfen
+         * Dass es zwei sind muss hier nicht mehr überprüft werden.
+         */
+        $fields = explode(',',$this->latLngInput->getValue());
+        $sql = rex_sql::factory();
+        $result = $sql->getArray(
+            'SELECT id,name FROM rex_yform_field WHERE table_name = :tn AND type_id = :ti AND (name = :lat OR name = :lng) AND no_db = :no',
+            [
+                ':tn' => $self->getParam('form_hiddenfields')['table_name'],
+                ':ti' => 'value',
+                ':lat' => $fields[0],
+                ':lng' => $fields[1],
+                ':no' => 1,
+            ],
+            PDO::FETCH_KEY_PAIR,
+        );
+
+        /**
+         * Fehler: Wenn es mindestens ein no_db-Koordinatenfeld gibt
+         */
+        if( 0 !== count($result)) {
+            $self->setElement(
+                'message',
+                sprintf(
+                    '"%s" kollidiert mit der Feldkonfiguration von «%s»; Beide Koordinatenfelder («%s») müssen speicherbar sein, wenn dieses Feld nicht speicherbar ist',
+                    rex_i18n::msg('yform_donotsaveindb'),
+                    implode('» bzw. «', $result),
+                    implode('», «', $fields),
+                )
+            );
+            return true;
+        }
+        return false;
     }
 }

--- a/lib/yfom/value/osm_geocode.php
+++ b/lib/yfom/value/osm_geocode.php
@@ -239,7 +239,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
             'SELECT id,name FROM ' . rex::getTable('yform_field') . ' WHERE type_id = :ti AND table_name = :tn',
             [
                 ':ti' => 'value',
-             ':tn' => $self->getParam('form_hiddenfields')['table_name'],
+                ':tn' => $self->getParam('form_hiddenfields')['table_name'],
             ],
             PDO::FETCH_KEY_PAIR,
         );
@@ -266,9 +266,8 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     /**
      * Validator für die Feld-Konfiguration
      * 
-     * Überprüft, ob die angegebenen Felder für Adress-Teile existieren.
+     * Überprüft, ob die Angaben zu no_db hier und in den latlng-Felder korrelieren.
      * Wenn nein: Fehlermeldung.
-     * Wenn ja: schon mal versehentlich eingegebene Leerzeichen entfernen.
      * 
      * @param array<rex_yform_value_abstract> $fields
      */

--- a/lib/yfom/value/osm_geocode.php
+++ b/lib/yfom/value/osm_geocode.php
@@ -2,20 +2,24 @@
 
 namespace FriendsOfRedaxo\YFormGeoOsm;
 
+use rex_functional_exception;
 use rex_i18n;
 use rex_yform_value_abstract;
-use rex_functional_exception;
+
+use function sprintf;
 
 class rex_yform_value_osm_geocode extends rex_yform_value_abstract
 {
-    public ?rex_yform_value_abstract $latField = null;
-    public ?rex_yform_value_abstract $lngField = null;
-    public bool $combinedValue = false;
+    protected ?rex_yform_value_abstract $latField = null;
+    protected ?rex_yform_value_abstract $lngField = null;
+    protected bool $combinedValue = false;
 
     /**
      * Die Hilfsfelder im Formular für Lat/Lng identifizieren.
      * Falls es reine Hilfsfelder sind (nicht in der DB speichern)
      * werden ggf. sie aus diesem Feld initialisiert.
+     *
+     * @api
      */
     public function preValidateAction(): void
     {
@@ -54,7 +58,10 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         }
     }
 
-    public function enterObject()
+    /**
+     * @api
+     */
+    public function enterObject(): void
     {
         $addressfields = explode(',', str_replace(' ', '', $this->getElement('address')));
         $geofields = [$this->latField->getName(), $this->lngField->getName()];
@@ -76,11 +83,18 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         }
     }
 
+    /**
+     * @api
+     */
     public function getDescription(): string
     {
         return 'osm_geocode|osmgeocode|Bezeichnung|pos_lat,pos_lng|strasse,plz,ort|height|[mapbox_token]|[no_db]';
     }
 
+    /**
+     * @api
+     * @return array<string, mixed>
+     */
     public function getDefinitions(): array
     {
         return [

--- a/ytemplates/bootstrap/value.osm_geocode.tpl.php
+++ b/ytemplates/bootstrap/value.osm_geocode.tpl.php
@@ -2,33 +2,41 @@
 
 use FriendsOfRedaxo\YFormGeoOsm\rex_yform_value_osm_geocode;
 
-/** @var rex_yform_value_osm_geocode $this */
+/**
+ * @var array<string> $addressfields
+ * @var array<string> $geofields
+ * @var string $mapbox_token
+ * @var int $height
+ * @var rex_yform_value_osm_geocode $this
+ */
 
 $class_group = trim('form-group yform-element ' . $this->getWarningClass());
 $class_label = 'control-label';
 
 $address_selectors = [];
 foreach ($addressfields as $afield) {
-    foreach ($this->params["values"] as $val) {
+    /** @var rex_yform_value_abstract $val */
+    foreach ($this->params['values'] as $val) {
         if ($val->getName() === $afield) {
-            $address_selectors[] = "#".$val->getFieldId();
+            $address_selectors[] = '#' . $val->getFieldId();
         }
     }
 }
 
 $geo_selectors = [];
-foreach ($this->params["values"] as $val) {
+/** @var rex_yform_value_abstract $val */
+foreach ($this->params['values'] as $val) {
     if ($val->getName() === $geofields[0]) {
-        $geo_selectors['lat'] = "#".$val->getFieldId();
+        $geo_selectors['lat'] = '#' . $val->getFieldId();
     }
     if ($val->getName() === $geofields[1]) {
-        $geo_selectors['lng'] = "#".$val->getFieldId();
+        $geo_selectors['lng'] = '#' . $val->getFieldId();
     }
 }
 
 $js = '<script type="text/javascript">
     jQuery(function($){
-        var rex_geo_osm_'.$this->getId().' = new rex_geo_osm('.json_encode($address_selectors).', '.json_encode($geo_selectors).', '.$this->getId().', "'.$mapbox_token.'");
+        var rex_geo_osm_' . $this->getId() . ' = new rex_geo_osm(' . json_encode($address_selectors) . ', ' . json_encode($geo_selectors) . ', ' . $this->getId() . ', "' . $mapbox_token . '");
     });
 </script>';
 
@@ -43,38 +51,38 @@ rex_extension::register('OUTPUT_FILTER', '\FriendsOfRedaxo\YFormGeoOsm\Assets::a
 	<br>
 	<div class="btn-group">
 		<button class="btn btn-primary set"
-			id="set-geo-<?=$this->getId()?>" type="button">
+			id="set-geo-<?= $this->getId()?>" type="button">
 			<i class="fa-solid fa-map-marker-alt"></i>
 			<?= rex_i18n::msg('yform_geo_osm_get_coords') ?>
 		</button>
 		<button class="btn btn-primary search"
-			id="search-geo-<?=$this->getId()?>" type="button">
+			id="search-geo-<?= $this->getId()?>" type="button">
 			<i class="fa-solid fa-magnifying-glass"></i>
 			<?= rex_i18n::msg('yform_geo_osm_search_address') ?>
 		</button>
 		<button class="btn btn-primary browser-location"
-			id="browser-geo-<?=$this->getId()?>" type="button">
+			id="browser-geo-<?= $this->getId()?>" type="button">
 			<i class="fa-solid fa-location-crosshairs"></i>
 			<?= rex_i18n::msg('yform_geo_osm_get_location') ?>
 		</button>
 	</div>
 
-	<div id="map-<?=$this->getId()?>"
-		style="height:<?=$height?>px; margin-top:5px;"></div>
+	<div id="map-<?= $this->getId()?>"
+		style="height:<?= $height?>px; margin-top:5px;"></div>
 
 	<!-- Search Modal -->
 	<div class="rex-geo-search-modal"
-		id="rex-geo-search-modal-<?=$this->getId()?>">
+		id="rex-geo-search-modal-<?= $this->getId()?>">
 		<div class="rex-geo-search-content">
 			<span class="rex-geo-search-close">&times;</span>
 			<div class="rex-geo-search-wrapper">
 				<input type="text"
-					id="rex-geo-search-input-<?=$this->getId()?>"
+					id="rex-geo-search-input-<?= $this->getId()?>"
 					class="rex-geo-search-input form-control input-lg"
 					placeholder="<?= rex_i18n::msg('yform_geo_osm_search_placeholder') ?>"
 					autocomplete="off">
 			</div>
-			<div id="rex-geo-search-results-<?=$this->getId()?>"
+			<div id="rex-geo-search-results-<?= $this->getId()?>"
 				class="search-results"></div>
 		</div>
 	</div>

--- a/ytemplates/bootstrap/value.osm_geocode.tpl.php
+++ b/ytemplates/bootstrap/value.osm_geocode.tpl.php
@@ -1,7 +1,5 @@
 <?php
 
-use FriendsOfRedaxo\YFormGeoOsm\rex_yform_value_osm_geocode;
-
 /**
  * @var array<string> $addressfields
  * @var array<string> $geofields


### PR DESCRIPTION
RexStan mit Level 7 auf die PHP-Dateien eingesetzt. Ausnahme _lib/Search.php_ und _pages/yform.yform_geo_osm.php_. In den beiden sind einige SQL-Statements, die sich ziemlich hartnäckige quer stellen. Das muss man später mal angehen.

In _lib/yform/value/osm_geocode.php_ wurden Validierungen der Feldkonfiguration hinzugefügt.

- Die Eingaben im Feld `latlng` werden überprüft auf gültige Feldnamen im Formular und dass es genau zwei Felder sind.
- Die Eingaben im Feld `address` werden überprüft, ob es gültige Feldnamen im Formular sind; leer ist zulässig.
- die Eingabe bei `no_db` wird quergeprüft zur Konfiguration der Felder aus `latlng`. Wenn hier `no_db==1` ist, dürfen die LatLng-Felder nicht ebenfalls `no_db==1` haben

Außerdem die Labels der Felder geändert: kürzer gefasst und die Erklärungen nach `notice` verschoben.

closes #32 