### PR TITLE
Kleinere Optimierungen im YForm-Value und seinem YTemplate

### DIFF
--- a/lib/yfom/value/osm_geocode.php
+++ b/lib/yfom/value/osm_geocode.php
@@ -52,9 +52,9 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
             if (null === $value) {
                 $value = ',';
             }
-            [$lat, $lng, $rest] = explode(',', $value . ',');
-            $this->latField->setValue($lat);
-            $this->lngField->setValue($lng);
+            $latLng = array_merge(explode(',', $value), ['','']);
+            $this->latField->setValue($latLng[0]);
+            $this->lngField->setValue($latLng[1]);
         }
     }
 
@@ -66,8 +66,15 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
      */
     public function enterObject(): void
     {
-        $addressfields = explode(',', str_replace(' ', '', $this->getElement('address')));
-        $geofields = [$this->latField->getName(), $this->lngField->getName()];
+        $fields = array_filter(explode(',', $this->getElement('address')),strlen(...));
+        $addressfields = [];
+        /** @var rex_yform_value_abstract $val */
+        foreach( $this->getParam('values') as $val) {
+            if(in_array($val->getName(),$fields,true)) {
+                $addressfields[$val->getName()] = $val;
+            }
+        }
+        $geofields = [$this->latField, $this->lngField];
         $height = (int) $this->getElement('height');
         $mapbox_token = $this->getElement('mapbox_token');
 

--- a/ytemplates/bootstrap/value.osm_geocode.tpl.php
+++ b/ytemplates/bootstrap/value.osm_geocode.tpl.php
@@ -39,6 +39,45 @@ $js = '<script type="text/javascript">
 </script>';
 
 rex_extension::register('OUTPUT_FILTER', '\FriendsOfRedaxo\YFormGeoOsm\Assets::addDynJs', rex_extension::LATE, ['js' => $js]);
+
+/**
+ * Kartenbutton mit Redaxo-Mitteln zusammenbauen.
+ */
+$fragment = new rex_fragment();
+$items = [];
+
+if (0 < count($address_selectors)) {
+    $items[] = [
+        'label' => '<i class="fa-solid fa-map-marker-alt"></i> ' . rex_i18n::msg('yform_geo_osm_get_coords'),
+        'attributes' => [
+            'class' => ['btn-primary', 'set'],
+            'type' => 'button',
+            'id' => 'set-geo-' . $this->getId(),
+        ],
+    ];
+}
+
+$items[] = [
+    'label' => '<i class="fa-solid fa-location-crosshairs"></i> ' . rex_i18n::msg('yform_geo_osm_search_address'),
+    'attributes' => [
+        'class' => ['btn-primary', 'search'],
+        'type' => 'button',
+        'id' => 'search-geo-' . $this->getId(),
+    ],
+];
+
+$items[] = [
+    'label' => '<i class="fa-solid fa-location-crosshairs"></i> ' . rex_i18n::msg('yform_geo_osm_get_location'),
+    'attributes' => [
+        'class' => ['btn-primary', 'browser-location'],
+        'type' => 'button',
+        'id' => 'browser-geo-' . $this->getId(),
+    ],
+];
+
+$fragment->setVar('buttons', $items, false);
+$buttonHTML = $fragment->parse('core/buttons/button_group.php');
+
 ?>
 
 <div class="<?= $class_group ?>"
@@ -46,24 +85,7 @@ rex_extension::register('OUTPUT_FILTER', '\FriendsOfRedaxo\YFormGeoOsm\Assets::a
 	<label
 		class="<?= $class_label ?>"><?= $this->getElement('label') ?></label>
 
-	<br>
-	<div class="btn-group">
-		<button class="btn btn-primary set"
-			id="set-geo-<?= $this->getId()?>" type="button">
-			<i class="fa-solid fa-map-marker-alt"></i>
-			<?= rex_i18n::msg('yform_geo_osm_get_coords') ?>
-		</button>
-		<button class="btn btn-primary search"
-			id="search-geo-<?= $this->getId()?>" type="button">
-			<i class="fa-solid fa-magnifying-glass"></i>
-			<?= rex_i18n::msg('yform_geo_osm_search_address') ?>
-		</button>
-		<button class="btn btn-primary browser-location"
-			id="browser-geo-<?= $this->getId()?>" type="button">
-			<i class="fa-solid fa-location-crosshairs"></i>
-			<?= rex_i18n::msg('yform_geo_osm_get_location') ?>
-		</button>
-	</div>
+	<br><?= $buttonHTML ?>
 
 	<div id="map-<?= $this->getId()?>"
 		style="height:<?= $height?>px; margin-top:5px;"></div>

--- a/ytemplates/bootstrap/value.osm_geocode.tpl.php
+++ b/ytemplates/bootstrap/value.osm_geocode.tpl.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @var array<string> $addressfields
- * @var array<string> $geofields
+ * @var array<string, rex_yform_value_abstract> $addressfields
+ * @var array<string, rex_yform_value_abstract> $geofields
  * @var string $mapbox_token
  * @var int $height
  * @var rex_yform_value_osm_geocode $this
@@ -13,24 +13,13 @@ $class_label = 'control-label';
 
 $address_selectors = [];
 foreach ($addressfields as $afield) {
-    /** @var rex_yform_value_abstract $val */
-    foreach ($this->params['values'] as $val) {
-        if ($val->getName() === $afield) {
-            $address_selectors[] = '#' . $val->getFieldId();
-        }
-    }
+	$address_selectors[] = '#' . $afield->getFieldId();
 }
 
-$geo_selectors = [];
-/** @var rex_yform_value_abstract $val */
-foreach ($this->params['values'] as $val) {
-    if ($val->getName() === $geofields[0]) {
-        $geo_selectors['lat'] = '#' . $val->getFieldId();
-    }
-    if ($val->getName() === $geofields[1]) {
-        $geo_selectors['lng'] = '#' . $val->getFieldId();
-    }
-}
+$geo_selectors = [
+	'lat' => '#' . $geofields[0]->getFieldId(),
+	'lng' => '#' . $geofields[1]->getFieldId(),
+];
 
 $js = '<script type="text/javascript">
     jQuery(function($){


### PR DESCRIPTION
Kleinere Optimierungen im YForm-Value und seinem YTemplate:

**Buttons neu strukturiert.**

- Der Button für "Koordinate aus den Adressfeldern ermitteln" wird nur dann eingebaut, wenn auch tatsächlich Adressfelder zugewiesen sind.
- Die Button sind im YFragment nicht mehr als Bootstrap-HTML geschrieben, sondern werden über das Buttons-Fragment generiert. Standards nutzen ...

** Arbeitsteilung zwischen YFragment und Value geändert.

- Insbesondere werden die zu den Feldnamen (Lat/Lng, Adressen-Teile) gehörenden Value-Objekte im YForm-Value ermittelt und nicht mehr im Template.
- Da bereits bei der Parametriesierung eines Feldes die Feldnamen "fehlerfrei", also ohne störende Leerstellen gespeichert werden, muss man das nicht auch noch extra prüfen.
- 
closes #39