### PR TITLE
JSON Attribute + Übersetzungen + dark mode fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,21 @@
 ## Version 2.0.0 //
 
 * Umstellung auf FriendsOfREDAXO-Namespace. @alxndr-w
-* Sprachdateien aktualisiert.
+* Geopicker für Module oder AddOns @skerbis
+* Sprachdateien aktualisiert  @skerbis
 * Von rexstan gemeldete Code-Verbesserungen umgesetzt. @alxndr-w @christophboecker
+* Konfiguration per JSON möglich, ersetzt das Height-Feld  @skerbis
+  * style und class Attribute
+  * Initiale Kartenposition (data-init-lat, data-init-lng)
+  * Initiales Zoom-Level (data-init-zoom)
+* Dark Mode Unterstützung verbessert:  @skerbis
+  * Integration der REDAXO Standard CSS-Variablen
+  * Optimierte Kartendarstellung
+  * Verbesserte Kontraste
+* UX Verbesserungen:  @skerbis
+  * Marker wird nicht mehr initial angezeigt
+  * Erscheint erst bei Positionsauswahl
+  * Verbesserte Transitionen
 
 ## Version 1.4.0 // 27.12.2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Version 2.0.0 //
 
 * Umstellung auf FriendsOfREDAXO-Namespace. @alxndr-w
-* Geopicker für Module oder AddOns @skerbis
 * Sprachdateien aktualisiert  @skerbis
 * Von rexstan gemeldete Code-Verbesserungen umgesetzt. @alxndr-w @christophboecker
 * Konfiguration per JSON möglich, ersetzt das Height-Feld  @skerbis
@@ -18,15 +17,17 @@
   * Marker wird nicht mehr initial angezeigt
   * Erscheint erst bei Positionsauswahl
   * Verbesserte Transitionen
-
-## Version 1.4.0 // 27.12.2024
-
-* Neue Funktionen für einzelne Adressabfragen
-* Verbesserte `geo_search`-Klasse mit drei Betriebsmodi:
+* Neue Funktionen für einzelne Adressabfragen  @skerbis
+* Verbesserte `geo_search`-Klasse mit drei Betriebsmodi:  @skerbis
   * Einzelabfrage
   * Batch-Geokodierung
   * PLZ-Umkreissuche
-* Erweiterte Dokumentation und Beispiele.
+* Erweiterte Dokumentation und Beispiele.  @skerbis
+* Karten im YForm-Value optimieren @christophboecker
+* Kleinere Optimierungen im YForm-Value und seinem YTemplate @christophboecker
+* RexStan eingesetzt, Value mit Validierung der Feldkonfiguration @christophboecker
+* no_db-Option und zugehörige Doku  @christophboecker
+* DB-Feldtyp varchar statt text / Speicherverhalten geändert  @christophboecker
 
 ## Version 1.3.0 // 27.12.2024
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 ### Format-Optionen (neu in 2.0.0)
 
+> Es ersetzt die Height-Angabe. Wird ein JSON gesetzt muss die Höhe über style oder class mitgegeben werden. 
+
 Die Kartenansicht kann über ein JSON-Objekt konfiguriert werden:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -1,54 +1,36 @@
-# YForm Geo OSM
+# YForm Erweiterung: Geo (OSM)
 
-Dieses Addon erweitert YForm um ein Geo-Feld für OpenStreetMap zur Koordinatenauswahl.
+![Screenshot](https://github.com/FriendsOfREDAXO/yform_geo_osm/blob/assets/screen.png?raw=true)
 
-![Screenshot](https://github.com/FriendsOfREDAXO/yform_geo_osm/assets/screenshots/yform_geo_osm.jpg)
-
-## Features
-
-* OpenStreetMap Integration für YForm
-* Adresssuche via Nominatim
-* Browser-Geolocation Support
-* Standortsuche mit Live-Vorschau
-* Drag & Drop Marker für präzise Positionierung
-* Dark Mode Support
-* Optional: Mapbox Integration
+* YForm-Erweiterung, um eine Geocoding-Funktion einzubinden. Basierend auf OpenStreetMap
+* Anpassung der Geodaten über Map-Marker möglich
+* Live-Suche für Adressen mit Vorschlägen
+* Browser-Standortbestimmung
+* OpenStreetMap (Straßenkarte), optional Mapbox (Straßenkarte + Satellitenbilder)
+* PHP-Klasse `Search` für:
+  * Einzelne Adressabfragen
+  * Umkreissuche basierend auf Postleitzahlen
+  * Batch-Geocodierung von Adressen auch außerhalb von YForm
 
 ## Installation
 
-1. Im REDAXO Installer das Addon `yform_geo_osm` herunterladen
-2. Addon installieren und aktivieren
-3. Optional: Mapbox Token in den Einstellungen hinterlegen
+* Paket herunterladen oder über den Installer installieren
+* Optional: Mapbox-Token für zusätzliche Kartenebenen (Layer)
+* Optional: Geoapify API-Key für erweiterte Geocoding-Funktionen
 
-## Verwendung in YForm
+## Features
 
-### 1. Geo-Feld anlegen
+### YForm-Feld `osm_geocode`
 
-Das Geo-Feld kann im YForm Formbuilder oder in der Table Manager Definition hinzugefügt werden:
+* Interaktive Kartenansicht mit Marker (Marker erscheint erst bei Positionsauswahl)
+* Live-Adresssuche mit Vorschlägen
+* Direkte Übernahme des Browser-Standorts
+* Automatische Koordinaten-Ermittlung aus Adressfeldern
+* Dark-Mode unterstützt
+* Responsive-Design
+* Flexible Konfiguration über JSON-Format
 
-```php
-osm_geocode|geo_position|Position|pos_lat,pos_lng|strasse,plz,ort
-```
-
-Parameter:
-1. Feldtyp (`osm_geocode`)
-2. Name des Feldes
-3. Label
-4. Koordinatenfelder (Latitude,Longitude)
-5. Adressfelder für die Koordinatenermittlung (optional)
-6. Format als JSON (optional)
-7. Mapbox Token (optional)
-
-### 2. Koordinatenfelder anlegen
-
-Die benötigten Koordinatenfelder müssen separat angelegt werden:
-
-```php
-number|pos_lat|Latitude||
-number|pos_lng|Longitude||
-```
-
-### 3. Format-Optionen (neu in 2.0.0)
+### Format-Optionen (neu in 2.0.0)
 
 Die Kartenansicht kann über ein JSON-Objekt konfiguriert werden:
 
@@ -68,63 +50,195 @@ Verfügbare Optionen:
 * `data-init-lng`: Initiale Longitude (Standard: 8.6821267)
 * `data-init-zoom`: Initiales Zoom-Level (Standard: 2)
 
-#### Legacy Format-Option
+> Hinweis: Die frühere Option der direkten Höhenangabe wird aus Kompatibilitätsgründen noch unterstützt, wenn keine JSON-Formatierung angegeben ist.
 
-Das Feld unterstützt aus Kompatibilitätsgründen auch noch die einfache Höhenangabe:
+### Geocodierungs-Funktionen
+
+Die `Search`-Klasse bietet verschiedene Möglichkeiten der Geocodierung:
+
+> Hinweis: wenn man anstelle des API-Keys `config` schreibt, wird der API-Key der `config` übernommen.
+
+#### 1. Abfrage einer einzelnen Adresse
 
 ```php
-osm_geocode|geo_position|Position|pos_lat,pos_lng|strasse,plz,ort|400
+namespace FriendsOfREDAXO\YFormGeoOSM;
+
+// Geocoder initialisieren
+$geocoder = Search::forGeocoding('optional-api-key');
+
+// Variante 1: Mit einzelnen Feldern
+$coords = $geocoder->geocodeAddress('Musterstr. 1', 'Berlin', '10115');
+
+// Variante 2: Mit kompletter Adresse
+$coords = $geocoder->geocode('Musterstr. 1, 10115 Berlin');
+
+if ($coords) {
+    echo "Latitude: {$coords['lat']}, Longitude: {$coords['lng']}";
+}
 ```
 
-Diese wird aber nur verwendet, wenn keine JSON-Formatierung angegeben ist.
+#### 2. Batch-Geokodierung
 
-## Beispiele
-
-### Einfaches Geo-Feld
+> Hinweis: dies setzt voraus, dass es zwei getrennte Felder für Längen- und Breitengrade gibt. Mit dem ebenfalls möglichen kombinierten Feld ist diese Funktion derzeit nicht möglich.
 
 ```php
-// Koordinatenfelder
-number|pos_lat|Latitude||
-number|pos_lng|Longitude||
+use FriendsOfRedaxo\YFormGeoOsm\Search;
+// Geocoder für Massenverarbeitung initialisieren
+$geocoder = Search::forBulkGeocoding(
+    'rex_my_addresses',           // Tabellenname
+    ['street', 'zip', 'city'],    // Adressfelder
+    'latitude',                   // Feld für Breitengrad
+    'longitude',                  // Feld für Längengrad
+    'your-geoapify-api-key',      // Optional: API Key
+    200                          // Optional: Batch-Größe
+);
 
-// Geo-Feld mit Standardeinstellungen
-osm_geocode|geo_position|Position|pos_lat,pos_lng
+// Batch verarbeiten
+$result = $geocoder->processBatch();
+printf(
+    "Verarbeitet: %d, Erfolgreich: %d, Fehlgeschlagen: %d",
+    $result['total'],
+    $result['success'],
+    $result['failed']
+);
 ```
 
-### Geo-Feld mit Adressverknüpfung
+#### 3. PLZ-Umkreissuche
+
+> Hinweis: dies setzt voraus, dass es zwei getrennte Felder für Längen- und Breitengrade gibt. Mit dem ebenfalls möglichen kombinierten Feld ist diese Funktion derzeit nicht möglich.
 
 ```php
-// Adressfelder
-text|strasse|Straße||
-text|plz|PLZ||
-text|ort|Ort||
+use FriendsOfRedaxo\YFormGeoOsm\Search;
+// Geocoder für PLZ-Suche initialisieren
+$geo = new Search(
+    [
+        'table' => 'rex_plz_data',
+        'lat_field' => 'lat',
+        'lng_field' => 'lng',
+        'postalcode_field' => 'plz'
+    ],
+    [
+        'table' => 'rex_my_addresses',
+        'lat_field' => 'latitude',
+        'lng_field' => 'longitude'
+    ]
+);
 
-// Koordinatenfelder
-number|pos_lat|Latitude||
-number|pos_lng|Longitude||
-
-// Geo-Feld mit Adressverknüpfung
-osm_geocode|geo_position|Position|pos_lat,pos_lng|strasse,plz,ort
+// Suche nach Adressen im Umkreis von 50km um PLZ 12345
+$results = $geo->searchByPostalcode('12345', 50);
 ```
 
-### Geo-Feld mit angepasster Initialisierung
+### YForm Integration
+
+#### Beispielmodul für YForm Frontend
 
 ```php
-// Koordinatenfelder
-number|pos_lat|Latitude||
-number|pos_lng|Longitude||
+rex_extension::register('OUTPUT_FILTER', FriendsOfRedaxo\YFormGeoOSM\Assets::addAssets(...));
 
-// Geo-Feld mit JSON-Formatierung
-osm_geocode|geo_position|Position|pos_lat,pos_lng||{"style": "height: 400px", "data-init-lat": "52.5200", "data-init-lng": "13.4050", "data-init-zoom": "12"}
+$yform = new rex_yform();
+$yform->setObjectparams('form_name', 'table-rex_geotest');
+$yform->setObjectparams('form_action',rex_getUrl('REX_ARTICLE_ID'));
+$yform->setObjectparams('form_ytemplate', 'bootstrap');
+$yform->setObjectparams('form_showformafterupdate', 0);
+$yform->setObjectparams('real_field_names', true);
+
+$yform->setValueField('text', ['street','Straße','','0']);
+$yform->setValueField('text', ['postalcode','PLZ','','0']);
+$yform->setValueField('text', ['city','Ort','','0']);
+$yform->setValueField('number', ['lat','LAT','10','7','','0','input:text']);
+$yform->setValueField('number', ['lng','LNG','11','8','','0','input:text']);
+$yform->setValueField('osm_geocode', ['osm','OSM','lat,lng','street,postalcode,city','{"style":"height: 400px"}','','','0']);
+
+echo $yform->getForm();
+```
+
+Die Koordinaten können entweder in den Einzelfeldern (`lat`, `lng`) oder im `osm_geocode`-Feld (`osm`) gespeichert
+werden. Dazu wird für den jeweils nicht benötigen Teil "Nicht in Datenbank speichern" festgelegt. Da im `osm_geocode`-Feld per Default keine Daten abgelegt werden, sondern in den Einzelfeldern, sollte wie im Beispiel 1 gezeigt das Feld gar nicht erst in der Datenbank angelegt werden.
+
+*Beispiel 1: Koordinaten als Einzelwerte `lat` bzw. `lng` speichern*
+
+```php
+$yform->setValueField('number', ['lat','LAT','10','7','','0','input:text']);
+$yform->setValueField('number', ['lng','LNG','11','8','','0','input:text']);
+$yform->setValueField('osm_geocode', ['osm','OSM','lat,lng','street,postalcode,city','{"style":"height: 400px"}','','','1']);
+```
+
+*Beispiel 2: Koordinaten als Kombiwert (`lat,lng`) in `osm` speichern*
+
+```php
+$yform->setValueField('number', ['lat','LAT','10','7','','1','input:text']);
+$yform->setValueField('number', ['lng','LNG','11','8','','1','input:text']);
+$yform->setValueField('osm_geocode', ['osm','OSM','lat,lng','street,postalcode,city','{"style":"height: 400px"}','','','0']);
+```
+
+### Batch-Geokodierung in YForm
+
+Die Batch-Geokodierung wird im YForm Reiter "Geo OSM" eingestellt:
+
+1. Tabelle mit Geocode-Feld auswählen
+2. Optional: Geoapify-API-Key eintragen
+3. Geocodierung starten
+4. Verarbeitung erfolgt in 200er-Schritten
+
+## API-Nutzung
+
+### Dienst: Nominatim
+
+- Standardmäßig wird Nominatim verwendet
+* Kostenlos, aber mit Nutzungsbeschränkungen
+* Rate Limit beachten
+
+### Dienst: Geoapify
+
+* Optional für erweiterte Funktionen
+* API-Key erforderlich
+* Höhere Limits möglich
+* Bessere Genauigkeit
+
+## Geopicker für Module / Add-ons Beispiel
+
+In diesem Fall werden die Koordinaten in einem Feld gespeichert. Das Feld muss die CSS-Klasse `rex-coords` besitzen.
+
+```html
+<div class="form-group">
+    <label>Location 1</label>
+    <input type="text" 
+           name="REX_INPUT_VALUE[1]" 
+           value="REX_VALUE[1]" 
+           class="form-control rex-coords"
+           readonly>
+</div>
+
+<div class="form-group">
+    <label>Location 2</label>
+    <input type="text" 
+           name="REX_INPUT_VALUE[2]" 
+           value="REX_VALUE[2]" 
+           class="form-control rex-coords"
+           readonly>
+</div>
 ```
 
 ## Lizenz
 
-MIT Lizenz, siehe [LICENSE.md](LICENSE.md)
+MIT-Lizenz, siehe [LICENSE](LICENSE)
 
-## Autor
+## Autoren
 
 **Friends Of REDAXO**
 
-* https://www.redaxo.org
-* https://github.com/FriendsOfREDAXO
+* <http://www.redaxo.org>
+* <https://github.com/FriendsOfREDAXO>
+
+**Project Lead**
+
+[Alexander Walther](https://github.com/alxndr-w)
+
+**Weitere Credits**
+
+* Polarpixel – Peter Bickel (Testing / Ideen)
+* Wolfgang Bund – Massencodierung
+* Leaflet
+* OpenStreetMap
+* Mapbox
+* Geoapify

--- a/assets/geo_osm.css
+++ b/assets/geo_osm.css
@@ -1,43 +1,51 @@
+/* REDAXO Standard-Variablen verwenden und erweitern */
 :root {
-   --rex-geo-background: #fff;
-   --rex-geo-background-hover: #f8f9fa;
-   --rex-geo-text: #212529;
-   --rex-geo-border: #dee2e6;
-   --rex-geo-input-bg: #fff;
-   --rex-geo-input-text: #212529;
-   --rex-geo-input-border: #dee2e6;
-   --rex-geo-shadow: rgba(0,0,0,0.1);
-   --rex-geo-primary: #2196F3;
-   --rex-geo-primary-hover: #1e87db;
-   --rex-geo-success: #4CAF50;
-   --rex-geo-success-hover: #45a049;
+    /* Bestehende REDAXO-Variablen */
+    --rex-background-color: #fff;
+    --rex-background-dark: #f3f6fb;
+    --rex-text-color: #212529;
+    --rex-link-color: #2196F3;
+    --rex-link-color-hover: #1e87db;
+    --rex-primary-color: #2196F3;
+    --rex-border-color: #ced4da;
+
+    /* Neue Variablen für Geo OSM */
+    --rex-geo-background: var(--rex-background-color);
+    --rex-geo-text: var(--rex-text-color);
+    --rex-geo-border: var(--rex-border-color);
+    --rex-geo-input-bg: var(--rex-background-color);
+    --rex-geo-input-text: var(--rex-text-color);
+    --rex-geo-input-border: var(--rex-border-color);
+    --rex-geo-shadow: rgba(0,0,0,0.1);
+    --rex-geo-primary: var(--rex-primary-color);
+    --rex-geo-primary-hover: var(--rex-link-color-hover);
+    --rex-geo-modal-backdrop: rgba(0,0,0,0.5);
 }
 
 /* Dark theme colors */
 :root[data-theme="dark"], 
-.rex-has-theme.rex-theme-dark {
-   --rex-geo-background: #32373c;
-   --rex-geo-background-hover: #3c4146;
-   --rex-geo-text: #fff;
-   --rex-geo-border: #404448;
-   --rex-geo-input-bg: #282c30;
-   --rex-geo-input-text: #fff;
-   --rex-geo-input-border: #404448;
-   --rex-geo-shadow: rgba(0,0,0,0.3);
+.rex-has-theme.rex-theme-dark,
+.rex-theme--dark {
+    /* REDAXO Dark Theme Variablen */
+    --rex-background-color: #32373c;
+    --rex-background-dark: #202428;
+    --rex-text-color: #f2f2f2;
+    --rex-link-color: #3f9ce7;
+    --rex-link-color-hover: #1b7dc5;
+    --rex-border-color: #404448;
+
+    /* Geo OSM Dark Theme */
+    --rex-geo-background: var(--rex-background-color);
+    --rex-geo-text: var(--rex-text-color);
+    --rex-geo-border: var(--rex-border-color);
+    --rex-geo-input-bg: var(--rex-background-dark);
+    --rex-geo-input-text: var(--rex-text-color);
+    --rex-geo-input-border: var(--rex-border-color);
+    --rex-geo-shadow: rgba(0,0,0,0.3);
+    --rex-geo-modal-backdrop: rgba(0,0,0,0.7);
 }
 
-@media (prefers-color-scheme: dark) {
-   :root {
-       --rex-geo-background: #32373c;
-       --rex-geo-background-hover: #3c4146;
-       --rex-geo-text: #fff;
-       --rex-geo-border: #404448;
-       --rex-geo-input-bg: #282c30;
-       --rex-geo-input-text: #fff;
-       --rex-geo-input-border: #404448;
-       --rex-geo-shadow: rgba(0,0,0,0.3);
-   }
-}
+/* Modal */
 .rex-geo-search-modal {
     display: none;
     position: fixed;
@@ -46,7 +54,7 @@
     top: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0,0,0,0.5);
+    background-color: var(--rex-geo-modal-backdrop);
 }
 
 .rex-geo-search-content {
@@ -54,7 +62,7 @@
     color: var(--rex-geo-text);
     margin: 10% auto;
     padding: 30px;
-    border-radius: 8px;
+    border-radius: 4px;
     width: 90%;
     max-width: 800px;
     position: relative;
@@ -70,6 +78,7 @@
     cursor: pointer;
     opacity: 0.7;
     color: var(--rex-geo-text);
+    transition: opacity 0.2s ease;
 }
 
 .rex-geo-search-close:hover {
@@ -83,19 +92,20 @@
 
 .rex-geo-search-input {
     width: 100%;
-    font-size: 24px !important;
-    padding: 15px !important;
-    border: 2px solid var(--rex-geo-input-border) !important;
-    border-radius: 8px !important;
+    font-size: 16px !important;
+    padding: 12px !important;
+    border: 1px solid var(--rex-geo-input-border) !important;
+    border-radius: 4px !important;
     height: auto !important;
     background-color: var(--rex-geo-input-bg) !important;
     color: var(--rex-geo-input-text) !important;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .rex-geo-search-input:focus {
     border-color: var(--rex-geo-primary) !important;
     outline: none;
-    box-shadow: 0 0 0 3px rgba(33,150,243,0.2) !important;
+    box-shadow: 0 0 0 2px rgba(33,150,243,0.2) !important;
 }
 
 .search-results {
@@ -109,40 +119,15 @@
     padding: 12px 15px;
     cursor: pointer;
     border-bottom: 1px solid var(--rex-geo-border);
-    transition: background-color 0.2s ease;
-    font-size: 16px;
     color: var(--rex-geo-text);
+    transition: background-color 0.2s ease;
 }
 
 .search-result:hover {
-    background-color: var(--rex-geo-background-hover);
+    background-color: var(--rex-background-dark);
 }
 
-.btn.browser-location {
-    background-color: var(--rex-geo-success);
-    border-color: var(--rex-geo-success);
-    color: #fff;
-}
-
-.btn.browser-location:hover {
-    background-color: var(--rex-geo-success-hover);
-    border-color: var(--rex-geo-success-hover);
-}
-
-.btn.search, 
-.btn.set {
-    background-color: var(--rex-geo-primary);
-    border-color: var(--rex-geo-primary);
-    color: #fff;
-}
-
-.btn.search:hover,
-.btn.set:hover {
-    background-color: var(--rex-geo-primary-hover);
-    border-color: var(--rex-geo-primary-hover);
-}
-
-
+/* Koordinaten Modal */
 .rex-coord-modal {
     display: none;
     position: fixed;
@@ -151,22 +136,23 @@
     top: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0,0,0,0.5);
+    background-color: var(--rex-geo-modal-backdrop);
 }
 
 .rex-coord-content {
-    background-color: #fff;
+    background-color: var(--rex-geo-background);
+    color: var(--rex-geo-text);
     margin: 5% auto;
     width: 90%;
     max-width: 900px;
-    border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    border-radius: 4px;
+    box-shadow: 0 2px 8px var(--rex-geo-shadow);
     overflow: hidden;
 }
 
 .rex-coord-header {
     padding: 15px 20px;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--rex-geo-border);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -175,12 +161,15 @@
 .rex-coord-header h3 {
     margin: 0;
     font-size: 18px;
+    color: var(--rex-geo-text);
 }
 
 .rex-coord-close {
     font-size: 24px;
     cursor: pointer;
     opacity: 0.7;
+    color: var(--rex-geo-text);
+    transition: opacity 0.2s ease;
 }
 
 .rex-coord-close:hover {
@@ -196,8 +185,17 @@
     width: 100%;
     padding: 10px;
     font-size: 16px;
-    border: 1px solid #ddd;
+    border: 1px solid var(--rex-geo-input-border);
     border-radius: 4px;
+    background-color: var(--rex-geo-input-bg);
+    color: var(--rex-geo-input-text);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#rex-coord-search-input:focus {
+    border-color: var(--rex-geo-primary);
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(33,150,243,0.2);
 }
 
 #rex-coord-search-results {
@@ -205,65 +203,61 @@
     top: 100%;
     left: 20px;
     right: 20px;
-    background: white;
-    border: 1px solid #ddd;
+    background: var(--rex-geo-background);
+    border: 1px solid var(--rex-geo-border);
     border-radius: 4px;
     max-height: 200px;
     overflow-y: auto;
     z-index: 2000;
 }
 
-.search-result {
-    padding: 10px;
-    cursor: pointer;
-    border-bottom: 1px solid #eee;
-}
-
-.search-result:hover {
-    background-color: #f5f5f5;
-}
-
 #rex-coord-map {
     height: 400px;
     width: 100%;
+    background-color: var(--rex-geo-background);
 }
 
 .rex-coord-footer {
     padding: 15px 20px;
-    border-top: 1px solid #eee;
+    border-top: 1px solid var(--rex-geo-border);
     text-align: right;
+    background-color: var(--rex-geo-background);
 }
 
 .rex-coord-footer button {
     margin-left: 10px;
 }
 
-/* Dark theme support */
-body.rex-has-theme.rex-theme-dark .rex-coord-content {
-    background-color: #32373c;
+/* Button Styles */
+.btn.browser-location {
+    background-color: var(--rex-geo-primary);
+    border-color: var(--rex-geo-primary);
     color: #fff;
 }
 
-body.rex-has-theme.rex-theme-dark .rex-coord-header,
-body.rex-has-theme.rex-theme-dark .rex-coord-footer {
-    border-color: #404448;
+.btn.browser-location:hover {
+    background-color: var(--rex-geo-primary-hover);
+    border-color: var(--rex-geo-primary-hover);
 }
 
-body.rex-has-theme.rex-theme-dark #rex-coord-search-input {
-    background-color: #282c30;
-    border-color: #404448;
+.btn.search, 
+.btn.set {
+    background-color: var(--rex-geo-primary);
+    border-color: var(--rex-geo-primary);
     color: #fff;
 }
 
-body.rex-has-theme.rex-theme-dark #rex-coord-search-results {
-    background-color: #32373c;
-    border-color: #404448;
+.btn.search:hover,
+.btn.set:hover {
+    background-color: var(--rex-geo-primary-hover);
+    border-color: var(--rex-geo-primary-hover);
 }
 
-body.rex-has-theme.rex-theme-dark .search-result {
-    border-color: #404448;
+/* Leaflet Map Dark Mode Anpassungen */
+.rex-has-theme.rex-theme-dark .leaflet-tile-pane {
+    filter: brightness(0.6) invert(1) contrast(3) hue-rotate(200deg) saturate(0.3) brightness(0.7);
 }
 
-body.rex-has-theme.rex-theme-dark .search-result:hover {
-    background-color: #3c4146;
+.rex-has-theme.rex-theme-dark .leaflet-container {
+    background: #303030;
 }

--- a/assets/geo_osm.js
+++ b/assets/geo_osm.js
@@ -23,22 +23,27 @@ var rex_geo_osm = function(addressfields, geofields, id, mapbox_token, options =
         this.getContainer()._leaflet_map = this;
     });
 
-    // Map initialization
-    var map;
-    let mapOptions = {
+    // Basis Map-Optionen
+    let defaultMapOptions = {
         center: current_lat && current_lng ? [current_lat, current_lng] : [initialLat, initialLng],
         zoom: defaultZoom,
         gestureHandling: true,
-        duration: 500,
-        ...options.mapOptions // Zusätzliche Leaflet-Optionen aus den options
-    }
+        duration: 500
+    };
+
+    // Map-Optionen mit benutzerdefinierten Optionen zusammenführen
+    let mapOptions = {
+        ...defaultMapOptions,
+        ...(options.mapOptions || {})
+    };
     
+    // Map initialization
+    var map;
     if(mapbox_token=='') {
         let streets = L.tileLayer('//{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png', {
             attribution: 'Map data © <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         });
-        mapOptions.layers = [streets];
-        map = L.map('map-'+id, mapOptions);
+        map = L.map('map-'+id, mapOptions).addLayer(streets);
     } else {
         var mapboxAttribution = 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
             '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
@@ -49,8 +54,7 @@ var rex_geo_osm = function(addressfields, geofields, id, mapbox_token, options =
             streets_sattelite = L.tileLayer('//api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token='+mapbox_token, 
             {id: 'mapbox.streets-satellite', attribution: mapboxAttribution});
 
-        mapOptions.layers = [streets, streets_sattelite];
-        map = L.map('map-'+id, mapOptions);
+        map = L.map('map-'+id, mapOptions).addLayer(streets);
 
         var baseMaps = {
             "Map": streets,
@@ -61,9 +65,14 @@ var rex_geo_osm = function(addressfields, geofields, id, mapbox_token, options =
     }
 
     var marker = null;
+    var defaultMarkerOptions = {
+        draggable: true
+    };
+    
+    // Marker-Optionen mit benutzerdefinierten Optionen zusammenführen
     var markerOptions = {
-        draggable: true,
-        ...options.markerOptions
+        ...defaultMarkerOptions,
+        ...(options.markerOptions || {})
     };
 
     // Marker nur erstellen wenn Koordinaten vorhanden sind

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -5,3 +5,24 @@ yform_geo_osm_search_address = Adresse suchen
 yform_geo_osm_get_location = Meinen Standort übernehmen
 yform_geo_osm_search = Suchen
 yform_geo_osm_search_placeholder = Adresse eingeben...
+
+# Fehlermeldungen und Validierung
+yform_geo_osm_error_coordinates = Bitte genau zwei Felder für Breiten- und Längengrade (lat, lng) angeben.
+yform_geo_osm_error_unknown_field = Koordinaten-Feld unbekannt: «%s»
+yform_geo_osm_error_address_field = Adress-Feld unbekannt: «%s»
+yform_geo_osm_error_format = Ungültige Formatierung. Bitte geben Sie ein gültiges JSON-Objekt ein.
+yform_geo_osm_error_no_db_conflict = "%s" kollidiert mit der Feldkonfiguration von «%s»; Beide Koordinatenfelder («%s») müssen speicherbar sein, wenn dieses Feld nicht speicherbar ist
+
+# Feldbezeichnungen
+yform_geo_osm_label_name = Name
+yform_geo_osm_label_label = Bezeichnung
+yform_geo_osm_label_coord_fields = Koordinaten-Felder
+yform_geo_osm_label_address_fields = Adressen-Felder
+yform_geo_osm_label_format = Format
+yform_geo_osm_label_mapbox_token = Mapbox-Token
+
+# Hilfetexte
+yform_geo_osm_notice_coord_fields = Namen der Felder für Breitengrad/Latitude und Längengrad/Longitude; Bsp.: «pos_lat,pos_lng»
+yform_geo_osm_notice_address_fields = Namen der Felder mit Adressen-Elementen zur Positionsfindung; Bsp.: «strasse,plz,ort»
+yform_geo_osm_notice_format = JSON-Objekt für Kartenformatierung und initiale Einstellungen. Beispiel: {"class":"wide","data-init-lat":"48.8566","data-init-lng":"2.3522","data-init-zoom":"10"}
+yform_geo_osm_notice_mapbox_token = (optional)

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -25,4 +25,5 @@ yform_geo_osm_label_mapbox_token = Mapbox-Token
 yform_geo_osm_notice_coord_fields = Namen der Felder für Breitengrad/Latitude und Längengrad/Longitude; Bsp.: «pos_lat,pos_lng»
 yform_geo_osm_notice_address_fields = Namen der Felder mit Adressen-Elementen zur Positionsfindung; Bsp.: «strasse,plz,ort»
 yform_geo_osm_notice_format = JSON-Objekt für Kartenformatierung und initiale Einstellungen. Beispiel: {"class":"wide","data-init-lat":"48.8566","data-init-lng":"2.3522","data-init-zoom":"10"}
+yform_geo_osm_notice_height = Angabe als Integer-Zahl ggf. mit Masseinheit px(default) | em | rem | vh. Legacy-Option, wird ignoriert wenn Format gesetzt ist.
 yform_geo_osm_notice_mapbox_token = (optional)

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -1,7 +1,28 @@
 yform_geo_osm = Geo (OSM)
-yform_geo_osm_overview = Geo (OSM) Overview
-yform_geo_osm_get_coords = Get coordinates from address
-yform_geo_osm_search_address = Search address
-yform_geo_osm_get_location = Get current location
-yform_geo_osm_search = Search
-yform_geo_osm_search_placeholder = Enter address...
+yform_geo_osm_overview = Geo (OSM) Übersicht
+yform_geo_osm_get_coords = Koordinaten von Adresse ermitteln
+yform_geo_osm_search_address = Adresse suchen
+yform_geo_osm_get_location = Meinen Standort übernehmen
+yform_geo_osm_search = Suchen
+yform_geo_osm_search_placeholder = Adresse eingeben...
+
+# Fehlermeldungen und Validierung
+yform_geo_osm_error_coordinates = Bitte genau zwei Felder für Breiten- und Längengrade (lat, lng) angeben.
+yform_geo_osm_error_unknown_field = Koordinaten-Feld unbekannt: «%s»
+yform_geo_osm_error_address_field = Adress-Feld unbekannt: «%s»
+yform_geo_osm_error_format = Ungültige Formatierung. Bitte geben Sie ein gültiges JSON-Objekt ein.
+yform_geo_osm_error_no_db_conflict = "%s" kollidiert mit der Feldkonfiguration von «%s»; Beide Koordinatenfelder («%s») müssen speicherbar sein, wenn dieses Feld nicht speicherbar ist
+
+# Feldbezeichnungen
+yform_geo_osm_label_name = Name
+yform_geo_osm_label_label = Bezeichnung
+yform_geo_osm_label_coord_fields = Koordinaten-Felder
+yform_geo_osm_label_address_fields = Adressen-Felder
+yform_geo_osm_label_format = Format
+yform_geo_osm_label_mapbox_token = Mapbox-Token
+
+# Hilfetexte
+yform_geo_osm_notice_coord_fields = Namen der Felder für Breitengrad/Latitude und Längengrad/Longitude; Bsp.: «pos_lat,pos_lng»
+yform_geo_osm_notice_address_fields = Namen der Felder mit Adressen-Elementen zur Positionsfindung; Bsp.: «strasse,plz,ort»
+yform_geo_osm_notice_format = JSON-Objekt für Kartenformatierung und initiale Einstellungen. Beispiel: {"class":"wide","data-init-lat":"48.8566","data-init-lng":"2.3522","data-init-zoom":"10"}
+yform_geo_osm_notice_mapbox_token = (optional)

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -1,28 +1,30 @@
 yform_geo_osm = Geo (OSM)
-yform_geo_osm_overview = Geo (OSM) Übersicht
-yform_geo_osm_get_coords = Koordinaten von Adresse ermitteln
-yform_geo_osm_search_address = Adresse suchen
-yform_geo_osm_get_location = Meinen Standort übernehmen
-yform_geo_osm_search = Suchen
-yform_geo_osm_search_placeholder = Adresse eingeben...
+yform_geo_osm_overview = Geo (OSM) Overview
+yform_geo_osm_get_coords = Get coordinates from address
+yform_geo_osm_search_address = Search address
+yform_geo_osm_get_location = Get current location
+yform_geo_osm_search = Search
+yform_geo_osm_search_placeholder = Enter address...
 
-# Fehlermeldungen und Validierung
-yform_geo_osm_error_coordinates = Bitte genau zwei Felder für Breiten- und Längengrade (lat, lng) angeben.
-yform_geo_osm_error_unknown_field = Koordinaten-Feld unbekannt: «%s»
-yform_geo_osm_error_address_field = Adress-Feld unbekannt: «%s»
-yform_geo_osm_error_format = Ungültige Formatierung. Bitte geben Sie ein gültiges JSON-Objekt ein.
-yform_geo_osm_error_no_db_conflict = "%s" kollidiert mit der Feldkonfiguration von «%s»; Beide Koordinatenfelder («%s») müssen speicherbar sein, wenn dieses Feld nicht speicherbar ist
+# Error messages and validation
+yform_geo_osm_error_coordinates = Please specify exactly two fields for latitude and longitude (lat, lng).
+yform_geo_osm_error_unknown_field = Coordinate field unknown: «%s»
+yform_geo_osm_error_address_field = Address field unknown: «%s»
+yform_geo_osm_error_format = Invalid formatting. Please enter a valid JSON object.
+yform_geo_osm_error_no_db_conflict = "%s" conflicts with the field configuration of «%s»; Both coordinate fields («%s») must be storable if this field is not storable
 
-# Feldbezeichnungen
+# Field labels
 yform_geo_osm_label_name = Name
-yform_geo_osm_label_label = Bezeichnung
-yform_geo_osm_label_coord_fields = Koordinaten-Felder
-yform_geo_osm_label_address_fields = Adressen-Felder
+yform_geo_osm_label_label = Label
+yform_geo_osm_label_coord_fields = Coordinate Fields
+yform_geo_osm_label_address_fields = Address Fields
 yform_geo_osm_label_format = Format
-yform_geo_osm_label_mapbox_token = Mapbox-Token
+yform_geo_osm_label_height = Map Height
+yform_geo_osm_label_mapbox_token = Mapbox Token
 
-# Hilfetexte
-yform_geo_osm_notice_coord_fields = Namen der Felder für Breitengrad/Latitude und Längengrad/Longitude; Bsp.: «pos_lat,pos_lng»
-yform_geo_osm_notice_address_fields = Namen der Felder mit Adressen-Elementen zur Positionsfindung; Bsp.: «strasse,plz,ort»
-yform_geo_osm_notice_format = JSON-Objekt für Kartenformatierung und initiale Einstellungen. Beispiel: {"class":"wide","data-init-lat":"48.8566","data-init-lng":"2.3522","data-init-zoom":"10"}
+# Help texts
+yform_geo_osm_notice_coord_fields = Names of the fields for latitude and longitude; Example: «pos_lat,pos_lng»
+yform_geo_osm_notice_address_fields = Names of the fields with address elements for position finding; Example: «street,zip,city»
+yform_geo_osm_notice_format = JSON object for map formatting and initial settings. Example: {"class":"wide","data-init-lat":"48.8566","data-init-lng":"2.3522","data-init-zoom":"10"}
+yform_geo_osm_notice_height = Value as integer number with optional unit px(default) | em | rem | vh. Legacy option, ignored if Format is set.
 yform_geo_osm_notice_mapbox_token = (optional)


### PR DESCRIPTION
# Konfigurationsformat für YForm Geo OSM vereinfacht und Dark Mode verbessert

Mit diesem PR wird das Konfigurationsformat für die Kartenansicht vereinfacht und der Dark Mode grundlegend überarbeitet.

## Änderungen

### Neues Format- und Konfigurationskonzept
- Einführung eines einfachen JSON-Formats für Karteneinstellungen 
  ```json
  {
      "style": "height: 400px",
      "data-init-lat": "52.5200",
      "data-init-lng": "13.4050",
      "data-init-zoom": "12"
  }
  ```
- Kompatibilität mit bestehender height-Option beibehalten

### Dark Mode und CSS
- Optimierte Kartendarstellung für Dark Mode (bessere Lesbarkeit, angepasste Kontraste)
- Modernere Transitions und Hover-Effekte
- Konsistenteres Look & Feel im Backend

### User Experience
- Marker wird erst bei Positionsauswahl angezeigt
- Vorauswahl der Position über data-Attribute möglich
- Verbesserte Hover-Zustände für Buttons und Interaktionselemente

## Migration

### Vor der Änderung:
```php
$yform->setValueField('osm_geocode', ['osm','OSM','lat,lng','street,postalcode,city','400']);
```

### Nach der Änderung:
```php
$yform->setValueField('osm_geocode', ['osm','OSM','lat,lng','street,postalcode,city','{"style":"height: 400px"}']);
```

### Optionale Konfiguration:
```php
// Mit initialer Position
$yform->setValueField('osm_geocode', ['osm','OSM','lat,lng','street,postalcode,city','{"style":"height: 400px","data-init-lat":"52.5200","data-init-lng":"13.4050","data-init-zoom":"12"}']);

// Mit zusätzlichen Klassen
$yform->setValueField('osm_geocode', ['osm','OSM','lat,lng','street,postalcode,city','{"style":"height: 400px","class":"my-custom-class"}']);
```

## Breaking Changes
- Marker wird initial nicht mehr angezeigt (erscheint erst bei Positionsauswahl).

## Getestete Szenarien
- Migration bestehender Felder (height-Option)
- Dark Mode Darstellung in verschiedenen Browsern
- Marker-Verhalten bei Positionsauswahl
- Initiale Kartenpositionen über data-Attribute
- CSS-Variablen im Light/Dark Mode


<img width="1029" alt="Bildschirmfoto 2025-01-02 um 21 19 27" src="https://github.com/user-attachments/assets/9335aad1-6296-4384-9c02-8b9c547f98ee" />

Alle Texte aus dem Value wurden in lng-dateien verschoben. Wie ich Übersetzungen für den Geopicker (für Module) erstelle weiß ich noch nicht. 

Dark-Mode wurde auch verbessert

<img width="1188" alt="Bildschirmfoto 2025-01-02 um 22 01 41" src="https://github.com/user-attachments/assets/19034a92-1ab1-43b1-a276-b8f02cee6838" />

<img width="943" alt="Bildschirmfoto 2025-01-02 um 22 01 31" src="https://github.com/user-attachments/assets/2b9aee8e-ede2-4b2e-94e8-49ba0542bbb8" />


fixes: https://github.com/FriendsOfREDAXO/yform_geo_osm/issues/41
fixes: https://github.com/FriendsOfREDAXO/yform_geo_osm/issues/37


👋 jetzt erstmal raus hier ... viel Spaß noch damit