### PR TITLE
YForm 4 erforderlich

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -5,7 +5,7 @@ supportpage: https://github.com/FriendsOfREDAXO/yform_geo_osm
 
 requires:
     packages:
-        yform/manager: '>=2'
+        yform/manager: '>=4'
     redaxo: '^5.17'
     php:
         version: '>=8.0, <9'


### PR DESCRIPTION
Soweit ich weiß, sind durch die Umstellung von YForm 3 zu 4 ohnehin bei eigenen Feldern return-Werte eingefordert, womit das Feld nicht rückwärtskompatibel ist.