### PR TITLE
Fehlende Variable $class_label gesetzt

### DIFF
--- a/ytemplates/bootstrap/value.osm_geocode.tpl.php
+++ b/ytemplates/bootstrap/value.osm_geocode.tpl.php
@@ -25,6 +25,9 @@ if (!empty($mapAttributes) && is_array($mapAttributes)) {
         $htmlAttributes .= ' ' . rex_escape($attr) . '="' . rex_escape($value) . '"';
     }
 }
+
+$class_label = 'control-label';
+
 ?>
 
 <div class="yform-geocoding-wrapper">


### PR DESCRIPTION
Behebt den Fehler aus #63.

$class_label auf den YForm-Standardwert gesetzt
`$class_label = 'control-label';`

closes #63