### PR TITLE
Rexstan-Überarbeitung

### DIFF
--- a/lib/yfom/value/osm_geocode.php
+++ b/lib/yfom/value/osm_geocode.php
@@ -45,6 +45,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     {
         if (null === $this->latField || null === $this->lngField) {
             $geofields = explode(',', str_replace(' ', '', $this->getElement('latlng')));
+            /** @var rex_yform_value_abstract $val */
             foreach ($this->params['values'] as $val) {
                 if ($val->getName() === $geofields[0]) {
                     $this->latField = $val;
@@ -77,9 +78,15 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
      */
     public function enterObject(): void
     {
+        /**
+         * STAN: Parameter #2 $callback of function array_filter expects (callable(string): bool)|null, Closure(string): int<0, max> given.
+         * NOTICE: ist valides PHP
+         * @phpstan-ignore-next-line
+         */
         $fields = array_filter(explode(',', $this->getElement('address')), strlen(...));
         $addressfields = [];
-        foreach ($this->params['values'] as $val) {
+            /** @var rex_yform_value_abstract $val */
+            foreach ($this->params['values'] as $val) {
             if (in_array($val->getName(), $fields, true)) {
                 $addressfields[$val->getName()] = $val;
             }
@@ -103,8 +110,9 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         }
 
         // Legacy support for height
+        /** @var string height */
         $height = $this->getElement('height');
-        if (empty($mapAttributes) && $height) {
+        if (0 === count($mapAttributes) && '' < $height) {
             $height = is_numeric($height) ? $height . 'px' : $height;
             $mapAttributes['style'] = 'height: ' . $height;
         }
@@ -130,6 +138,10 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         return rex_i18n::msg('osm_geocode_description');
     }
 
+    /**
+     * 
+     * @return array<string, mixed> 
+     */
     public function getDefinitions(): array
     {
         return [
@@ -191,6 +203,11 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     {
         // Eingabe in ein Array auflösen und formal bereinigen
         $coord_field_names = array_map(trim(...), explode(',', $value));
+        /**
+         * STAN: Parameter #2 $callback of function array_filter expects (callable(string): bool)|null, Closure(string): int<0, max> given.
+         * NOTICE: ist valides PHP
+         * @phpstan-ignore-next-line
+         */
         $coord_field_names = array_filter($coord_field_names, strlen(...));
         $coord_field_names = array_unique($coord_field_names);
 
@@ -239,12 +256,17 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
      */
     protected function validateAddress(string $field_name, string $value, bool $return, rex_yform_validate_customfunction $self, array $fields): bool
     {
-        if(empty(trim($value))) {
+        if('' < (trim($value))) {
             return false;
         }
 
         // Eingabe in ein Array auflösen und formal bereinigen
         $address_field_names = array_map(trim(...), explode(',', $value));
+        /**
+         * STAN: Parameter #2 $callback of function array_filter expects (callable(string): bool)|null, Closure(string): int<0, max> given.
+         * NOTICE: ist valides PHP
+         * @phpstan-ignore-next-line
+         */
         $address_field_names = array_filter($address_field_names, strlen(...));
         $address_field_names = array_unique($address_field_names);
 
@@ -337,7 +359,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     protected function validateLayout(array $field_names, array $values, bool $return, rex_yform_validate_customfunction $self, array $fields): bool
     {
         // Prüfen der map_attributes, wenn vorhanden
-        if (!empty($values['map_attributes'])) {
+        if ('' < ($values['map_attributes'])) {
             try {
                 $attributes = json_decode($values['map_attributes'], true, 512, JSON_THROW_ON_ERROR);
                 if (!is_array($attributes)) {
@@ -359,7 +381,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
 
         // Prüfen der height, wenn map_attributes nicht gesetzt ist
         $height = $values['height'] ?? '';
-        if (empty($height)) {
+        if ('' < $height) {
             $fields['height']->setValue('400px');
             return false;
         }

--- a/lib/yfom/value/osm_geocode.php
+++ b/lib/yfom/value/osm_geocode.php
@@ -15,26 +15,22 @@ use function sprintf;
 class rex_yform_value_osm_geocode extends rex_yform_value_abstract
 {
     /**
-     * Reference to the latitude field
-     * @var rex_yform_value_abstract|null
+     * Reference to the latitude field.
      */
     protected ?rex_yform_value_abstract $latField = null;
 
     /**
-     * Reference to the longitude field
-     * @var rex_yform_value_abstract|null
+     * Reference to the longitude field.
      */
     protected ?rex_yform_value_abstract $lngField = null;
 
     /**
-     * Whether to store coordinates as combined value
-     * @var bool
+     * Whether to store coordinates as combined value.
      */
     protected bool $combinedValue = false;
 
     /**
-     * Reference to the input field for validation
-     * @var rex_yform_value_abstract|null
+     * Reference to the input field for validation.
      */
     protected ?rex_yform_value_abstract $latLngInput = null;
 
@@ -67,7 +63,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
             if (null === $value) {
                 $value = ',';
             }
-            $latLng = array_merge(explode(',', $value), ['','']);
+            $latLng = array_merge(explode(',', $value), ['', '']);
             $this->latField->setValue($latLng[0]);
             $this->lngField->setValue($latLng[1]);
         }
@@ -80,13 +76,13 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     {
         /**
          * STAN: Parameter #2 $callback of function array_filter expects (callable(string): bool)|null, Closure(string): int<0, max> given.
-         * NOTICE: ist valides PHP
+         * NOTICE: ist valides PHP.
          * @phpstan-ignore-next-line
          */
         $fields = array_filter(explode(',', $this->getElement('address')), strlen(...));
         $addressfields = [];
-            /** @var rex_yform_value_abstract $val */
-            foreach ($this->params['values'] as $val) {
+        /** @var rex_yform_value_abstract $val */
+        foreach ($this->params['values'] as $val) {
             if (in_array($val->getName(), $fields, true)) {
                 $addressfields[$val->getName()] = $val;
             }
@@ -103,7 +99,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
                 if (!is_array($mapAttributes)) {
                     $mapAttributes = [];
                 }
-            } catch (\JsonException $e) {
+            } catch (JsonException $e) {
                 // Invalid JSON, fallback to empty array
                 $mapAttributes = [];
             }
@@ -122,7 +118,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         if ($this->needsOutput()) {
             $this->params['form_output'][$this->getId()] = $this->parse(
                 'value.osm_geocode.tpl.php',
-                compact('addressfields', 'geofields', 'mapAttributes', 'mapbox_token')
+                compact('addressfields', 'geofields', 'mapAttributes', 'mapbox_token'),
             );
         }
 
@@ -133,14 +129,14 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
             $this->params['value_pool']['sql'][$this->getName()] = $this->getValue();
         }
     }
+
     public function getDescription(): string
     {
         return rex_i18n::msg('osm_geocode_description');
     }
 
     /**
-     * 
-     * @return array<string, mixed> 
+     * @return array<string, mixed>
      */
     public function getDefinitions(): array
     {
@@ -153,35 +149,35 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
                 'latlng' => [
                     'type' => 'text',
                     'label' => rex_i18n::msg('osm_geocode_latlng_label'),
-                    'notice' => rex_i18n::msg('osm_geocode_latlng_notice')
+                    'notice' => rex_i18n::msg('osm_geocode_latlng_notice'),
                 ],
                 'address' => [
                     'type' => 'text',
                     'label' => rex_i18n::msg('osm_geocode_address_label'),
-                    'notice' => rex_i18n::msg('osm_geocode_address_notice')
+                    'notice' => rex_i18n::msg('osm_geocode_address_notice'),
                 ],
                 'height' => [
                     'type' => 'text',
                     'label' => rex_i18n::msg('osm_geocode_height_label'),
-                    'notice' => rex_i18n::msg('osm_geocode_height_notice')
+                    'notice' => rex_i18n::msg('osm_geocode_height_notice'),
                 ],
                 'map_attributes' => [
                     'type' => 'text',
                     'label' => rex_i18n::msg('osm_geocode_map_attributes_label'),
-                    'notice' => rex_i18n::msg('osm_geocode_map_attributes_notice')
+                    'notice' => rex_i18n::msg('osm_geocode_map_attributes_notice'),
                 ],
                 'mapbox_token' => [
                     'type' => 'text',
                     'label' => rex_i18n::msg('osm_geocode_mapbox_token_label'),
-                    'notice' => rex_i18n::msg('osm_geocode_mapbox_token_notice')
+                    'notice' => rex_i18n::msg('osm_geocode_mapbox_token_notice'),
                 ],
-                'no_db' => ['type' => 'no_db', 'default' => 0]
+                'no_db' => ['type' => 'no_db', 'default' => 0],
             ],
             'validates' => [
                 ['customfunction' => ['name' => 'latlng', 'function' => $this->validateLatLng(...)]],
                 ['customfunction' => ['name' => 'address', 'function' => $this->validateAddress(...)]],
                 ['customfunction' => ['name' => 'no_db', 'function' => $this->validateNoDb(...)]],
-                ['customfunction' => ['name' => ['height', 'map_attributes'], 'function' => $this->validateLayout(...)]]
+                ['customfunction' => ['name' => ['height', 'map_attributes'], 'function' => $this->validateLayout(...)]],
             ],
             'description' => rex_i18n::msg('osm_geocode_description_full'),
             'dbtype' => 'varchar(191)',
@@ -191,7 +187,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     }
 
     /**
-     * Validator für die Feld-Konfiguration
+     * Validator für die Feld-Konfiguration.
      *
      * Überprüft, ob die angegebenen Felder für LAT/LNG existieren.
      * Wenn nein: Fehlermeldung.
@@ -205,7 +201,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         $coord_field_names = array_map(trim(...), explode(',', $value));
         /**
          * STAN: Parameter #2 $callback of function array_filter expects (callable(string): bool)|null, Closure(string): int<0, max> given.
-         * NOTICE: ist valides PHP
+         * NOTICE: ist valides PHP.
          * @phpstan-ignore-next-line
          */
         $coord_field_names = array_filter($coord_field_names, strlen(...));
@@ -215,7 +211,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         if (2 !== count($coord_field_names)) {
             $self->setElement(
                 'message',
-                rex_i18n::msg('osm_geocode_validate_latlng_count')
+                rex_i18n::msg('osm_geocode_validate_latlng_count'),
             );
             return true;
         }
@@ -236,7 +232,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         if (0 < count($unknown_fields)) {
             $self->setElement(
                 'message',
-                sprintf(rex_i18n::msg('osm_geocode_validate_latlng_unknown'), implode('», «', $unknown_fields))
+                sprintf(rex_i18n::msg('osm_geocode_validate_latlng_unknown'), implode('», «', $unknown_fields)),
             );
             return true;
         }
@@ -248,7 +244,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     }
 
     /**
-     * Validator für die Feld-Konfiguration
+     * Validator für die Feld-Konfiguration.
      *
      * Überprüft, ob die angegebenen Felder für Adress-Teile existieren.
      *
@@ -256,7 +252,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
      */
     protected function validateAddress(string $field_name, string $value, bool $return, rex_yform_validate_customfunction $self, array $fields): bool
     {
-        if('' < (trim($value))) {
+        if ('' < trim($value)) {
             return false;
         }
 
@@ -264,7 +260,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         $address_field_names = array_map(trim(...), explode(',', $value));
         /**
          * STAN: Parameter #2 $callback of function array_filter expects (callable(string): bool)|null, Closure(string): int<0, max> given.
-         * NOTICE: ist valides PHP
+         * NOTICE: ist valides PHP.
          * @phpstan-ignore-next-line
          */
         $address_field_names = array_filter($address_field_names, strlen(...));
@@ -286,7 +282,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         if (0 < count($unknown_fields)) {
             $self->setElement(
                 'message',
-               sprintf(rex_i18n::msg('osm_geocode_validate_address_unknown'), implode('», «', $unknown_fields))
+                sprintf(rex_i18n::msg('osm_geocode_validate_address_unknown'), implode('», «', $unknown_fields)),
             );
             return true;
         }
@@ -297,7 +293,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     }
 
     /**
-     * Validator für die Feld-Konfiguration
+     * Validator für die Feld-Konfiguration.
      *
      * Überprüft, ob die Angaben zu no_db hier und in den latlng-Felder korrelieren.
      *
@@ -306,7 +302,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     protected function validateNoDb(string $field_name, ?int $value, bool $return, rex_yform_validate_customfunction $self, array $fields): bool
     {
         // Überspringen wenn selbst speicherbar
-        if ($value === null || $value === 0 || !isset($this->latLngInput)) {
+        if (null === $value || 0 === $value || !isset($this->latLngInput)) {
             return false;
         }
 
@@ -329,14 +325,14 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         if (0 !== count($result)) {
             $self->setElement(
                 'message',
-                 sprintf(
-                     rex_i18n::msg(
-                         'osm_geocode_validate_nodb_conflict',
-                         rex_i18n::msg('yform_donotsaveindb')
-                     ),
+                sprintf(
+                    rex_i18n::msg(
+                        'osm_geocode_validate_nodb_conflict',
+                        rex_i18n::msg('yform_donotsaveindb'),
+                    ),
                     implode('» bzw. «', $result),
-                    implode('», «', $coord_fields)
-                    )
+                    implode('», «', $coord_fields),
+                ),
             );
             return true;
         }
@@ -344,7 +340,7 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
     }
 
     /**
-     * Validator für die Feld-Konfiguration
+     * Validator für die Feld-Konfiguration.
      *
      * Überprüft, ob die Angaben map_attributes valid sind und die height korrekt ist.
      * - map_attributes muss valides JSON sein
@@ -352,27 +348,27 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
      * - die Massangabe darf sein px, em, rem oder vh. px ist default
      * - wenn kein Feld gefüllt ist, wird 400px als Höhe eingetragen (default)
      *
-     * @param string[] $field_names
+     * @param array<string> $field_names
      * @param array<string, string> $values
      * @param array<rex_yform_value_abstract> $fields
      */
     protected function validateLayout(array $field_names, array $values, bool $return, rex_yform_validate_customfunction $self, array $fields): bool
     {
         // Prüfen der map_attributes, wenn vorhanden
-        if ('' < ($values['map_attributes'])) {
+        if ('' < $values['map_attributes']) {
             try {
                 $attributes = json_decode($values['map_attributes'], true, 512, JSON_THROW_ON_ERROR);
                 if (!is_array($attributes)) {
                     $self->setElement(
                         'message',
-                         rex_i18n::msg('osm_geocode_validate_map_attributes_invalid')
+                        rex_i18n::msg('osm_geocode_validate_map_attributes_invalid'),
                     );
                     return true;
                 }
-            } catch (\JsonException $e) {
+            } catch (JsonException $e) {
                 $self->setElement(
                     'message',
-                    sprintf(rex_i18n::msg('osm_geocode_validate_map_attributes_json_error'), $e->getMessage())
+                    sprintf(rex_i18n::msg('osm_geocode_validate_map_attributes_json_error'), $e->getMessage()),
                 );
                 return true;
             }
@@ -391,14 +387,14 @@ class rex_yform_value_osm_geocode extends rex_yform_value_abstract
         if (0 === $ok) {
             $self->setElement(
                 'message',
-                 sprintf(rex_i18n::msg('osm_geocode_validate_height_invalid'), $height)
+                sprintf(rex_i18n::msg('osm_geocode_validate_height_invalid'), $height),
             );
             return true;
         }
 
         $match = array_merge(
             ['height' => '', 'unit' => 'px'],
-            $match
+            $match,
         );
         $fields['height']->setValue(sprintf('%d%s', $match['height'], $match['unit']));
         return false;

--- a/pages/yform.manager.yform_geo_osm.php
+++ b/pages/yform.manager.yform_geo_osm.php
@@ -116,7 +116,7 @@ echo '
     </form>';
 
 
-if ($table) {
+if (null !== $table) {
     $content = '';
     $func = rex_request('geo_func', 'string');
     $field = rex_request('geo_field', 'string');
@@ -160,13 +160,13 @@ if ($table) {
             $data_lat = rex_request('geo_lat', 'string');
             $data_id = rex_request('geo_id', 'int', 0);
             $pos_fields = explode(',', $fields[$field]['latlng']);
-            $pos_field = $fields[$field]['name'];
+            $pos_field = isset($fields[$field]['name']) ? $fields[$field]['name'] : '';
             if (count($pos_fields) === 2) {
                 $pos_lat = $pos_fields[0];
                 $pos_lng = $pos_fields[1];
                 $gd = \rex_sql::factory();
-                $gd->setQuery('select id, ' . $gd->escapeIdentifier($pos_lat) . ', ' . $gd->escapeIdentifier($pos_lng) . ' from ' . $table['table_name'] . ' where id = ' . $gd->escape($data_id) . '');
-                if ($gd->getRows() === 1 && $data_lng != '' && $data_lat != '') {
+                $gd->setQuery('select id, ' . $gd->escapeIdentifier($pos_lat) . ', ' . $gd->escapeIdentifier($pos_lng) . ' from ' . $table['table_name'] . ' where id = ' . $gd->escape((string)$data_id) . '');
+                if ($gd->getRows() === 1 && $data_lng !== '' && $data_lat !== '') {
                     $sd = \rex_sql::factory();
                     $sd->setTable($table['table_name']);
                     $sd->setWhere('id=' . $data_id);
@@ -175,10 +175,10 @@ if ($table) {
                     $sd->update();
                     $data = '1';
                 }
-            } elseif ($pos_field) {
+            } elseif ('' < $pos_field ) {
                 $gd = \rex_sql::factory();
-                $gd->setQuery('select id from ' . $table['table_name'] . ' where id = ' . (string) $gd->escape($data_id));
-                if ($gd->getRows() === 1 && $data_lng != '' && $data_lat != '') {
+                $gd->setQuery('select id from ' . $table['table_name'] . ' where id = ' . $gd->escape((string)$data_id));
+                if ($gd->getRows() === 1 && $data_lng !== '' && $data_lat !== '') {
                     $geopos = $data_lat . ',' . $data_lng;
                     $sd = \rex_sql::factory();
                     $sd->setTable($table['table_name']);

--- a/pages/yform.manager.yform_geo_osm.php
+++ b/pages/yform.manager.yform_geo_osm.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Aus Codeschnippseln verschiedener Addons
+ * Aus Codeschnippseln verschiedener Addons.
  */
 
 namespace FriendsOfREDAXO\YFormGeoOSM;
@@ -16,7 +16,7 @@ $geosql = \rex_sql::factory();
 $table = null;
 $addon = \rex_addon::get('yform_geo_osm');
 
-if (rex_request('config-submit', 'int', 0) === 1) {
+if (1 === rex_request('config-submit', 'int', 0)) {
     $addon->setConfig('geoapifykey', rex_request('geoapifykey', 'string'));
 }
 
@@ -25,7 +25,7 @@ $geo_tables = [];
 $fields = [];
 foreach ($tables as $i_table) {
     $fields = $i_table->getValueFields(['type_name' => 'osm_geocode']);
-    if (count($fields) > 0) {
+    if (\count($fields) > 0) {
         $geo_tables[$i_table->getTableName()] = $i_table;
         if ($table_name === $i_table->getTableName()) {
             $table = $i_table;
@@ -33,7 +33,6 @@ foreach ($tables as $i_table) {
         }
     }
 }
-
 
 $sel_table = new \rex_select();
 $sel_table->setId('osm-geo-table');
@@ -51,7 +50,6 @@ $content = '<p>Für die Geocodierung ist ein API Key von <a href="https://www.ge
 
 $content .= '<fieldset>';
 
-
 $formElements = [];
 $n = [];
 $n['field'] = '<input type="text" value="' . $addon->getConfig('geoapifykey') . '" name="geoapifykey" class="form-control">';
@@ -62,8 +60,6 @@ $fragment = new \rex_fragment();
 $fragment->setVar('elements', $formElements, false);
 $content .= $fragment->parse('core/form/form.php');
 
-
-
 $formElements = [];
 $n = [];
 $n['label'] = '<label for="osm-geo-table">Tabelle</label>';
@@ -73,8 +69,6 @@ $formElements[] = $n;
 $fragment = new \rex_fragment();
 $fragment->setVar('elements', $formElements, false);
 $content .= $fragment->parse('core/form/form.php');
-
-
 
 $formElements = [];
 $n = [];
@@ -89,22 +83,22 @@ $buttons = $fragment->parse('core/form/submit.php');
 $buttonlist = '';
 
 // Links zu Backend-Seiten
-$help_url = \rex_url::backendPage('packages', ["subpage" => "help", "package" => "yform_geo_osm"]);
-$changelog_url = \rex_url::backendPage('packages', ["subpage" => "changelog", "package" => "yform_geo_osm"]);
-$license_url = \rex_url::backendPage('packages', ["subpage" => "license", "package" => "yform_geo_osm"]);
+$help_url = \rex_url::backendPage('packages', ['subpage' => 'help', 'package' => 'yform_geo_osm']);
+$changelog_url = \rex_url::backendPage('packages', ['subpage' => 'changelog', 'package' => 'yform_geo_osm']);
+$license_url = \rex_url::backendPage('packages', ['subpage' => 'license', 'package' => 'yform_geo_osm']);
 
 $buttonlist = '<div class="btn-group" role="group">
-	<a href="'. $help_url .'"
-		class="btn btn-primary btn-sm">'. $addon->i18n('yform_geo_osm.help') .'</a>
-	<a href="'. $changelog_url .'"
-		class="btn btn-primary btn-sm">'. $addon->i18n('yform_geo_osm.changelog') .'</a>
-	<a href="'. $license_url .'"
-		class="btn btn-primary btn-sm">'. $addon->i18n('yform_geo_osm.license') .'</a>
+	<a href="' . $help_url . '"
+		class="btn btn-primary btn-sm">' . $addon->i18n('yform_geo_osm.help') . '</a>
+	<a href="' . $changelog_url . '"
+		class="btn btn-primary btn-sm">' . $addon->i18n('yform_geo_osm.changelog') . '</a>
+	<a href="' . $license_url . '"
+		class="btn btn-primary btn-sm">' . $addon->i18n('yform_geo_osm.license') . '</a>
 </div>';
 
 $fragment = new \rex_fragment();
 $fragment->setVar('class', 'edit');
-$fragment->setVar('title', $addon->i18n("yform_geo_osm.batch_geocoding.title"));
+$fragment->setVar('title', $addon->i18n('yform_geo_osm.batch_geocoding.title'));
 $fragment->setVar('options', $buttonlist, false);
 $fragment->setVar('body', $content, false);
 $fragment->setVar('buttons', $buttons, false);
@@ -115,7 +109,6 @@ echo '
         ' . $content . '
     </form>';
 
-
 if (null !== $table) {
     $content = '';
     $func = rex_request('geo_func', 'string');
@@ -124,10 +117,10 @@ if (null !== $table) {
     $geo_sql = \rex_sql::factory();
     //    $geo_sql->setDebug();
 
-    if ($func === 'get_data') {
+    if ('get_data' === $func) {
         $data = [];
         ob_end_clean();
-        if (array_key_exists($field, $fields)) {
+        if (\array_key_exists($field, $fields)) {
             $address_fields = explode(',', $fields[$field]['address']);
             $fs = [];
             foreach ($address_fields as $f) {
@@ -137,14 +130,14 @@ if (null !== $table) {
 
             $pos_fields = explode(',', $fields[$field]['latlng']); // das Element position gibt es nicht
             $pos_field = $fields[$field]['name'];
-            if (count($pos_fields) === 2) {
+            if (2 === \count($pos_fields)) {
                 $pos_lat = $pos_fields[0];
                 $pos_lng = $pos_fields[1];
                 $geo_sql->setQuery('select id, ' . $concat . ' from ' . $table['table_name'] . ' where ' . $pos_lng . '="" or ' . $pos_lng . ' IS NULL or ' . $pos_lat . '="" or ' . $pos_lat . ' IS NULL LIMIT 3000');
-                $data = ($geo_sql->getArray());
+                $data = $geo_sql->getArray();
             } elseif ($pos_field) {
                 $geo_sql->setQuery('select id, ' . $concat . ' from ' . $table['table_name'] . ' where ' . $pos_field . '="" or ' . $pos_field . ' IS NULL LIMIT 3000');
-                $data = ($geo_sql->getArray());
+                $data = $geo_sql->getArray();
             }
         }
         echo json_encode($data);
@@ -152,21 +145,21 @@ if (null !== $table) {
         exit;
     }
 
-    if ($func === 'save_data') {
+    if ('save_data' === $func) {
         ob_end_clean();
         $data = '0';
-        if (array_key_exists($field, $fields)) {
+        if (\array_key_exists($field, $fields)) {
             $data_lng = rex_request('geo_lng', 'string');
             $data_lat = rex_request('geo_lat', 'string');
             $data_id = rex_request('geo_id', 'int', 0);
             $pos_fields = explode(',', $fields[$field]['latlng']);
-            $pos_field = isset($fields[$field]['name']) ? $fields[$field]['name'] : '';
-            if (count($pos_fields) === 2) {
+            $pos_field = $fields[$field]['name'] ?? '';
+            if (2 === \count($pos_fields)) {
                 $pos_lat = $pos_fields[0];
                 $pos_lng = $pos_fields[1];
                 $gd = \rex_sql::factory();
-                $gd->setQuery('select id, ' . $gd->escapeIdentifier($pos_lat) . ', ' . $gd->escapeIdentifier($pos_lng) . ' from ' . $table['table_name'] . ' where id = ' . $gd->escape((string)$data_id) . '');
-                if ($gd->getRows() === 1 && $data_lng !== '' && $data_lat !== '') {
+                $gd->setQuery('select id, ' . $gd->escapeIdentifier($pos_lat) . ', ' . $gd->escapeIdentifier($pos_lng) . ' from ' . $table['table_name'] . ' where id = ' . $gd->escape((string) $data_id) . '');
+                if (1 === $gd->getRows() && '' !== $data_lng && '' !== $data_lat) {
                     $sd = \rex_sql::factory();
                     $sd->setTable($table['table_name']);
                     $sd->setWhere('id=' . $data_id);
@@ -175,10 +168,10 @@ if (null !== $table) {
                     $sd->update();
                     $data = '1';
                 }
-            } elseif ('' < $pos_field ) {
+            } elseif ('' < $pos_field) {
                 $gd = \rex_sql::factory();
-                $gd->setQuery('select id from ' . $table['table_name'] . ' where id = ' . $gd->escape((string)$data_id));
-                if ($gd->getRows() === 1 && $data_lng !== '' && $data_lat !== '') {
+                $gd->setQuery('select id from ' . $table['table_name'] . ' where id = ' . $gd->escape((string) $data_id));
+                if (1 === $gd->getRows() && '' !== $data_lng && '' !== $data_lat) {
                     $geopos = $data_lat . ',' . $data_lng;
                     $sd = \rex_sql::factory();
                     $sd->setTable($table['table_name']);

--- a/ytemplates/bootstrap/value.osm_geocode.tpl.php
+++ b/ytemplates/bootstrap/value.osm_geocode.tpl.php
@@ -4,7 +4,7 @@
  * @var array<rex_yform_value_abstract> $geofields
  * @var array<string, string> $mapAttributes
  * @var string|null $mapbox_token
- * 
+ *
  * @var rex_yform_value_osm_geocode $this
  */
 
@@ -67,7 +67,7 @@ $class_label = 'control-label';
             </div>
         </div>
         </div>
-        
+
     </div>
 </div>
 
@@ -81,7 +81,7 @@ document.addEventListener('DOMContentLoaded', function() {
         },
         '<?= $fieldId ?>',
         <?= null !== $mapbox_token ? json_encode($mapbox_token) : 'null' ?>,
-        <?= count($mapAttributes) === 0 ? json_encode($mapAttributes) : 'null' ?>
+        <?= 0 === count($mapAttributes) ? json_encode($mapAttributes) : 'null' ?>
     );
 });
 </script>

--- a/ytemplates/bootstrap/value.osm_geocode.tpl.php
+++ b/ytemplates/bootstrap/value.osm_geocode.tpl.php
@@ -4,6 +4,8 @@
  * @var array<rex_yform_value_abstract> $geofields
  * @var array<string, string> $mapAttributes
  * @var string|null $mapbox_token
+ * 
+ * @var rex_yform_value_osm_geocode $this
  */
 
 $fieldId = $this->getId();
@@ -20,10 +22,8 @@ $lng = $geofields[1]->getFieldId();
 
 // Build HTML attributes string for map div
 $htmlAttributes = '';
-if (!empty($mapAttributes) && is_array($mapAttributes)) {
-    foreach ($mapAttributes as $attr => $value) {
-        $htmlAttributes .= ' ' . rex_escape($attr) . '="' . rex_escape($value) . '"';
-    }
+foreach ($mapAttributes as $attr => $value) {
+    $htmlAttributes .= ' ' . rex_escape($attr) . '="' . rex_escape($value) . '"';
 }
 
 $class_label = 'control-label';
@@ -80,8 +80,8 @@ document.addEventListener('DOMContentLoaded', function() {
             lng: '#<?= $lng ?>'
         },
         '<?= $fieldId ?>',
-        <?= $mapbox_token ? json_encode($mapbox_token) : 'null' ?>,
-        <?= !empty($mapAttributes) ? json_encode($mapAttributes) : 'null' ?>
+        <?= null !== $mapbox_token ? json_encode($mapbox_token) : 'null' ?>,
+        <?= count($mapAttributes) === 0 ? json_encode($mapAttributes) : 'null' ?>
     );
 });
 </script>


### PR DESCRIPTION
Die Rexstan-Issues in _rexyform_geo_osm/ytemplates/bootstrap/value.osm_geocode.tpl.php_ drehten sich fast alle um `$mapAttributes`. Letzlich ist durch das YForm-Value schon sichergestellt, dass $mapAttributes (1) existiert und (2) ein Array ist. Alle diesbezüglichen Absicherungen rausgeworfen bzw. typspezifisch formuliert und schon gibt Rexstan Ruhe.

Die Issues in _exyform_geo_osm/lib/yform/values/osm_geocode.php_ drehen sich meist um`empty()` etc., was nicht nicht benutzt bzw. spezifischer formuliert werden sollte. Wenn der Typ eh klar ist ...

Außerdem wurde an drei Stellen Callback in `array_filter(...)` angemeckert. Das habe ich jetzt mal so gelöst.
```
/**
* STAN: Parameter #2 $callback of function array_filter expects (callable(string): bool)|null, Closure(string): int<0, max> given.
* NOTICE: ist valides PHP
* @phpstan-ignore-next-line
*/
```

In _yform_geo_osm/pages/yform.manager.yform_geo_osm.php_  wurden einige Abfragen und Vergleiche ("loose comparison") genauer spezifiziert. Was noch bleibt sind solche Geschichten
<img width="346" alt="grafik" src="https://github.com/user-attachments/assets/67689ab3-b5de-4019-a5e7-ca4430facf2c" />
Umstellen auf getValue?